### PR TITLE
Fix lazy-loaded chunk enhancement

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,9 +80,7 @@ SubresourceIntegrityPlugin.prototype.apply = function apply(compiler) {
      * Double plug-in registration in order to push our
      * plugin to the end of the plugin stack.
      */
-    compiler.plugin('this-compilation', function thisCompilationPlugin(thisCompilation) {
-      thisCompilation.mainTemplate.apply(new WebIntegrityJsonpMainTemplatePlugin());
-    });
+    thisCompilation.mainTemplate.apply(new WebIntegrityJsonpMainTemplatePlugin());
 
     /*
      *  Calculate SRI values for each chunk and replace the magic


### PR DESCRIPTION
The current version seems to have an issue with applying the [WebIntegrityJsonpMainTemplatePlugin](https://github.com/waysact/webpack-subresource-integrity/blob/master/index.js#L17) as the compiler  step of `this-compilation` is not triggered. Since [not documented at the official wiki pages](https://github.com/webpack/docs/wiki/plugins#the-compiler-instance) (at least regarding latest stable webpack 1.X branch) I've opted to call it directly.