### PR TITLE
Fix to get this working with new webpack beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ node_js:
 addons:
   firefox: latest
 env:
-  - SUFFIX=
-  - SUFFIX=@beta
+  - WEBPACK_SUFFIX=
+  - WEBPACK_SUFFIX=@beta
 install:
   - npm install --ignore-scripts
   - npm rm webpack
   - npm rm extract-text-webpack-plugin
-  - npm install "webpack""$SUFFIX" --ignore-scripts
-  - npm install "extract-text-webpack-plugin""$SUFFIX" --ignore-scripts
+  - npm install "webpack""$WEBPACK_SUFFIX" --ignore-scripts || true
+  - npm install "extract-text-webpack-plugin""$WEBPACK_SUFFIX" --ignore-scripts || true
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ node_js:
   - 4.2
 addons:
   firefox: latest
+env:
+  - WEBPACK=webpack
+  - WEBPACK=webpack@beta
+install:
+  - npm install --ignore-scripts
+  - npm rm webpack
+  - npm install $WEBPACK --ignore-scripts || true
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ node_js:
 addons:
   firefox: latest
 env:
-  - WEBPACK=webpack
-  - WEBPACK=webpack@beta
+  - SUFFIX=
+  - SUFFIX=@beta
 install:
   - npm install --ignore-scripts
   - npm rm webpack
-  - npm install $WEBPACK --ignore-scripts || true
+  - npm rm extract-text-webpack-plugin
+  - npm install "webpack""$SUFFIX" --ignore-scripts
+  - npm install "extract-text-webpack-plugin""$SUFFIX" --ignore-scripts
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/index.js
+++ b/index.js
@@ -131,6 +131,7 @@ SubresourceIntegrityPlugin.prototype.apply = function apply(compiler) {
       }
 
       compilation.chunks.forEach(function forEachChunk(chunk) {
+        // chunk.entry was removed in Webpack 2. Use hasRuntime() for this check instead (if it exists)
         if (('hasRuntime' in chunk && chunk.hasRuntime()) || chunk.entry) {
           processChunkRecursive(chunk);
         }

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ SubresourceIntegrityPlugin.prototype.apply = function apply(compiler) {
 
       compilation.chunks.forEach(function forEachChunk(chunk) {
         // chunk.entry was removed in Webpack 2. Use hasRuntime() for this check instead (if it exists)
-        if (('hasRuntime' in chunk && chunk.hasRuntime()) || chunk.entry) {
+        if (('hasRuntime' in chunk) ? chunk.hasRuntime() : chunk.entry) {
           processChunkRecursive(chunk);
         }
       });

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ SubresourceIntegrityPlugin.prototype.apply = function apply(compiler) {
       }
 
       compilation.chunks.forEach(function forEachChunk(chunk) {
-        if (chunk.entry) {
+        if (('hasRuntime' in chunk && chunk.hasRuntime()) || chunk.entry) {
           processChunkRecursive(chunk);
         }
       });

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack": "^1.12.11"
   },
   "peerDependencies": {
-    "webpack": "^1.12.11 || >2.1.0-beta <= 2.1.0"
+    "webpack": "^1.12.11 || >=2.1.0-beta <3.0"
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack": "^1.12.11"
   },
   "peerDependencies": {
-    "webpack": "^1.12.11"
+    "webpack": "^1.12.11 || >2.1.0-beta <= 2.1.0"
   },
   "files": [
     "LICENSE",

--- a/test/chunk2.js
+++ b/test/chunk2.js
@@ -1,7 +1,6 @@
 var expect = require('expect');
 
 module.exports = function chunk2(callback) {
-  var resourcesWithIntegrity = [];
   function forEachElement(el) {
     var src = el.getAttribute('src') || el.getAttribute('href');
     var integrity = el.getAttribute('integrity');
@@ -12,10 +11,16 @@ module.exports = function chunk2(callback) {
       }
     }
   }
-  Array.prototype.slice.call(document.getElementsByTagName('script')).forEach(forEachElement);
-  Array.prototype.slice.call(document.getElementsByTagName('link')).forEach(forEachElement);
-  resourcesWithIntegrity.sort();
-  expect(resourcesWithIntegrity).toEqual(['1.chunk.js', '2.chunk.js', 'stylesheet.css', 'test.js']);
-  expect(window.getComputedStyle(document.getElementsByTagName('body')[0]).backgroundColor).toEqual('rgb(200, 201, 202)');
-  callback();
+  try {
+    var resourcesWithIntegrity = [];
+    Array.prototype.slice.call(document.getElementsByTagName('script')).forEach(forEachElement);
+    Array.prototype.slice.call(document.getElementsByTagName('link')).forEach(forEachElement);
+    expect(resourcesWithIntegrity).toInclude('stylesheet.css');
+    expect(resourcesWithIntegrity).toInclude('test.js');
+    expect(resourcesWithIntegrity.filter(function filter(item) { return item.match(/^\d+\.chunk.js$/); }).length).toBe(2);
+    expect(window.getComputedStyle(document.getElementsByTagName('body')[0]).backgroundColor).toEqual('rgb(200, 201, 202)');
+    callback();
+  } catch (e) {
+    callback(e);
+  }
 };

--- a/test/test-webpack.js
+++ b/test/test-webpack.js
@@ -8,6 +8,7 @@ var select = require('soupselect').select;
 var expect = require('expect');
 var tmp = require('tmp');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var ExtractTextPluginVersion = require('extract-text-webpack-plugin/package.json').version;
 var CommonsChunkPlugin = require('webpack/lib/optimize/CommonsChunkPlugin');
 
 describe('webpack-subresource-integrity', function describe() {
@@ -81,6 +82,14 @@ describe('html-webpack-plugin', function describe() {
       fs.unlinkSync(path.join(tmpDir.name, 'bundle.js'));
       tmpDir.removeCallback();
     }
+    var extractTextLoader;
+    if (ExtractTextPluginVersion.match(/^1\./)) {
+      // extract-text-webpack-plugin 1.x
+      extractTextLoader = ExtractTextPlugin.extract('style-loader', 'css-loader');
+    } else {
+      // extract-text-webpack-plugin 2.x
+      extractTextLoader = ExtractTextPlugin.extract({ fallbackLoader: 'style-loader', loader: 'css-loader' });
+    }
     var webpackConfig = {
       entry: path.join(__dirname, './dummy.js'),
       output: {
@@ -89,7 +98,7 @@ describe('html-webpack-plugin', function describe() {
       },
       module: {
         loaders: [
-          { test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }
+          { test: /\.css$/, loader: extractTextLoader }
         ]
       },
       plugins: [

--- a/test/test-webpack.js
+++ b/test/test-webpack.js
@@ -23,7 +23,8 @@ describe('webpack-subresource-integrity', function describe() {
         chunk2: path.join(__dirname, './chunk2.js')
       },
       output: {
-        path: tmpDir.name
+        path: tmpDir.name,
+        filename: 'bundle.js'
       },
       plugins: [
         new CommonsChunkPlugin({ name: 'chunk1', chunks: ['chunk2'] }),
@@ -53,7 +54,8 @@ describe('html-webpack-plugin', function describe() {
     var webpackConfig = {
       entry: path.join(__dirname, './a.js'),
       output: {
-        path: tmpDir.name
+        path: tmpDir.name,
+        filename: 'bundle.js'
       },
       plugins: [
         new HtmlWebpackPlugin({ favicon: 'test/test.png' }),
@@ -82,7 +84,8 @@ describe('html-webpack-plugin', function describe() {
     var webpackConfig = {
       entry: path.join(__dirname, './dummy.js'),
       output: {
-        path: tmpDir.name
+        path: tmpDir.name,
+        filename: 'bundle.js'
       },
       module: {
         loaders: [


### PR DESCRIPTION
This is a small one-line change to get this library working with one of the newer betas of Webpack 2.

They removed `chunk.entry` and replaced it with `chunk.hasRuntime`. This change just does a check to see if `hasRuntime` exists in the chunk, and uses it if it does (falling back to using chunk.entry if it doesn't).

let me know if there are any changes you need me to make before merging, i'll be happy to do them.