### PR TITLE
Compatibility with html-webpack-plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ SubresourceIntegrityPlugin.prototype.apply = function apply(compiler) {
 
       pluginArgs.head.filter(filterTag).forEach(processTag);
       pluginArgs.body.filter(filterTag).forEach(processTag);
-      callback(null);
+      callback(null, pluginArgs);
     }
     /*
       *  html-webpack support:


### PR DESCRIPTION
https://github.com/ampedandwired/html-webpack-plugin/commit/4e29b022b89a6eeb7ba93ba92d0e955e83d2b997 deprecated using `html-webpack-plugin-after-html-processing` without returning a result; this commit resolves this deprecation message.