### PR TITLE
Deprecate crossorigin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ npm install webpack-subresource-integrity --save-dev
 import SriPlugin from 'webpack-subresource-integrity';
 
 const compiler = webpack({
+    output: {
+        crossOriginLoading: 'anonymous',
+    },
     plugins: [
         new SriPlugin({
             hashFuncNames: ['sha256', 'sha384'],
             enabled: process.env.NODE_ENV === 'production',
-            crossorigin: 'anonymous',
         }),
     ],
 });
@@ -46,8 +48,10 @@ HTML pages.)
 #### With HtmlWebpackPlugin
 
 When html-webpack-plugin is injecting assets into the template (the
-default), the `integrity` attribute will be set automatically.  There
-is nothing else to be done.
+default), the `integrity` attribute will be set automatically.  The
+`crossorigin` attribute will be set as well, to the value of
+`output.crossOriginLoading` webpack option. There is nothing else to
+be done.
 
 #### With HtmlWebpackPlugin({ inject: false })
 
@@ -60,7 +64,7 @@ template as follows:
   <script
      src="<%= htmlWebpackPlugin.files.js[index] %>"
      integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>"
-     crossorigin="<%= htmlWebpackPlugin.options.sriCrossOrigin %>"
+     crossorigin="<%= webpackConfig.output.crossOriginLoading %>"
   ></script>
 <% } %>
 
@@ -68,7 +72,7 @@ template as follows:
   <link
      href="<%= htmlWebpackPlugin.files.css[index] %>"
      integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>"
-     crossorigin="<%= htmlWebpackPlugin.options.sriCrossOrigin %>"
+     crossorigin="<%= webpackConfig.output.crossOriginLoading %>"
      rel="stylesheet"
   />
 <% } %>
@@ -87,6 +91,10 @@ compiler.plugin("done", stats => {
     const integrity = stats.compilation.assets[mainAssetName].integrity;
 });
 ```
+
+Note that you're also required to set the `crossorigin` attribute.  It
+is recommended to set this attribute to the same value as the webpack
+`output.crossOriginLoading` configuration option.
 
 ### Options
 
@@ -110,19 +118,22 @@ development mode.
 
 #### crossorigin
 
-Default value: `"anonymous"`
+**DEPRECATED**. Use webpack option `output.crossOriginLoading'
+instead'.
 
-When using `HtmlWebpackPlugin({ inject: true })`, this option
+~~Default value: `"anonymous"`~~
+
+~~When using `HtmlWebpackPlugin({ inject: true })`, this option
 specifies the value to be used for the `crossorigin` attribute for
-injected assets.
+injected assets.~~
 
-The value will also be available as
+~~The value will also be available as
 `htmlWebpackPlugin.options.sriCrossOrigin` in html-webpack-plugin
-templates.
+templates.~~
 
-See
+~~See
 [SRI: Cross-origin data leakage](https://www.w3.org/TR/SRI/#cross-origin-data-leakage) and
-[MDN: CORS settings attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)
+[MDN: CORS settings attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)~~
 
 ## Caveats
 

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ SubresourceIntegrityPlugin.prototype.validateOptions = function validateOptions(
       'Please update your code. ' +
         'See https://github.com/waysact/webpack-subresource-integrity/issues/18 for more information.');
   }
-  if (!compilation.compiler.options.output.crossOriginLoading) {
+  if (this.options.enabled && !compilation.compiler.options.output.crossOriginLoading) {
     this.warnOnce(
       compilation,
       'Set webpack option output.crossOriginLoading when using this plugin.');

--- a/index.js
+++ b/index.js
@@ -120,6 +120,10 @@ SubresourceIntegrityPlugin.prototype.error = function error(compilation, message
 };
 
 SubresourceIntegrityPlugin.prototype.validateOptions = function validateOptions(compilation) {
+  if (this.optionsValidated) {
+    return;
+  }
+  this.optionsValidated = true;
   if (this.options.deprecatedOptions) {
     this.warnOnce(
       compilation,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,10 +42,10 @@ function nextCreate(filesPromise, serveStaticFile, serveFile, injector, basePath
       response.write = function nextWrite(chunk, encoding) {
         var nextChunk = chunk.replace(
           'src="/base/test/test.js',
-          'integrity="' + toplevelScriptIntegrity + '" src="/base/test/test.js');
+          'integrity="' + toplevelScriptIntegrity + '" crossorigin="anonymous" src="/base/test/test.js');
         nextChunk = nextChunk.replace(
           'rel="stylesheet"',
-          'rel="stylesheet" integrity="' + stylesheetIntegrity + '"'
+          'rel="stylesheet" integrity="' + stylesheetIntegrity + '" crossorigin="anonymous"'
         );
         prevWrite.call(response, nextChunk, encoding);
       };
@@ -82,8 +82,13 @@ module.exports = function karmaConfig(config) {
       'karma-mocha'
     ],
     webpack: {
+      output: {
+        crossOriginLoading: 'anonymous'
+      },
       plugins: [
-        new SriPlugin(['sha256', 'sha384']),
+        new SriPlugin({
+          hashFuncNames: ['sha256', 'sha384']
+        }),
         new GetIntegrityPlugin()
       ],
       module: {

--- a/test/chunk2.js
+++ b/test/chunk2.js
@@ -4,9 +4,10 @@ module.exports = function chunk2(callback) {
   function forEachElement(el) {
     var src = el.getAttribute('src') || el.getAttribute('href');
     var integrity = el.getAttribute('integrity');
+    var crossorigin = el.getAttribute('crossOrigin');
     if (src) {
       var match = src.match(/[^\/]+\.(js|css)/);
-      if (match && integrity && integrity.match(/^sha\d+-/)) {
+      if (match && crossorigin && integrity && integrity.match(/^sha\d+-/)) {
         resourcesWithIntegrity.push(match[0].toString());
       }
     }

--- a/test/index.ejs
+++ b/test/index.ejs
@@ -1,14 +1,14 @@
 <% for (var index in htmlWebpackPlugin.files.js) { %>
   <script src="<%= htmlWebpackPlugin.files.js[index] %>"
           integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>"
-          crossorigin="<%= htmlWebpackPlugin.options.sriCrossOrigin %>"
+          crossorigin="<%= webpackConfig.output.crossOriginLoading %>"
   ></script>
 <% } %>
 
 <% for (var index in htmlWebpackPlugin.files.css) { %>
   <link href="<%= htmlWebpackPlugin.files.css[index] %>"
         integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>"
-        crossorigin="<%= htmlWebpackPlugin.options.sriCrossOrigin %>"
+        crossorigin="<%= webpackConfig.output.crossOriginLoading %>"
         rel="stylesheet"
   />
 <% } %>

--- a/test/test-webpack.js
+++ b/test/test-webpack.js
@@ -206,6 +206,7 @@ describe('webpack-subresource-integrity', function describe() {
     var tmpDir = tmp.dirSync();
     function cleanup(err) {
       fs.unlinkSync(path.join(tmpDir.name, 'bundle.js'));
+      fs.unlinkSync(path.join(tmpDir.name, 'styles.css'));
       tmpDir.removeCallback();
       callback(err);
     }
@@ -213,15 +214,22 @@ describe('webpack-subresource-integrity', function describe() {
       entry: path.join(__dirname, './dummy.js'),
       output: {
         path: tmpDir.name,
-        filename: 'bundle.js',
-        crossOriginLoading: 'anonymous'
+        filename: 'bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: createExtractTextLoader() }
+        ]
       },
       plugins: [
+        new ExtractTextPlugin('styles.css'),
         new SriPlugin({ hashFuncNames: ['sha256'], enabled: false })
       ]
     };
     webpack(webpackConfig, function webpackCallback(err, result) {
       expect(typeof result.compilation.assets['bundle.js'].integrity).toBe('undefined');
+      expect(result.compilation.warnings).toEqual([]);
+      expect(result.compilation.errors).toEqual([]);
       cleanup(err);
     });
   });

--- a/test/test-webpack.js
+++ b/test/test-webpack.js
@@ -21,6 +21,20 @@ function createExtractTextLoader() {
   return ExtractTextPlugin.extract({ fallbackLoader: 'style-loader', loader: 'css-loader' });
 }
 
+function testCompilation() {
+  return {
+    warnings: [],
+    errors: [],
+    compiler: {
+      options: {
+        output: {
+          crossOriginLoading: 'anonymous'
+        }
+      }
+    }
+  };
+}
+
 describe('webpack-subresource-integrity', function describe() {
   it('should handle circular dependencies gracefully', function it(callback) {
     var tmpDir = tmp.dirSync();
@@ -35,7 +49,8 @@ describe('webpack-subresource-integrity', function describe() {
       },
       output: {
         path: tmpDir.name,
-        filename: 'bundle.js'
+        filename: 'bundle.js',
+        crossOriginLoading: 'anonymous'
       },
       plugins: [
         new CommonsChunkPlugin({ name: 'chunk1', chunks: ['chunk2'] }),
@@ -79,7 +94,8 @@ describe('webpack-subresource-integrity', function describe() {
       output: {
         path: tmpDir.name,
         filename: 'bundle.js',
-        chunkFilename: 'chunk.js'
+        chunkFilename: 'chunk.js',
+        crossOriginLoading: 'anonymous'
       },
       plugins: [
         new SriPlugin({ hashFuncNames: ['sha256', 'sha384'] })
@@ -138,7 +154,8 @@ describe('webpack-subresource-integrity', function describe() {
            entry: path.join(__dirname, './dummy.js'),
            output: {
              path: tmpDir.name,
-             filename: 'bundle.js'
+             filename: 'bundle.js',
+             crossOriginLoading: 'anonymous'
            },
            plugins: [
              plugins[pluginOrder[0]],
@@ -168,7 +185,8 @@ describe('webpack-subresource-integrity', function describe() {
       entry: path.join(__dirname, './dummy.js'),
       output: {
         path: tmpDir.name,
-        filename: 'bundle.js'
+        filename: 'bundle.js',
+        crossOriginLoading: 'anonymous'
       },
       plugins: [
         new webpack.HotModuleReplacementPlugin(),
@@ -195,7 +213,8 @@ describe('webpack-subresource-integrity', function describe() {
       entry: path.join(__dirname, './dummy.js'),
       output: {
         path: tmpDir.name,
-        filename: 'bundle.js'
+        filename: 'bundle.js',
+        crossOriginLoading: 'anonymous'
       },
       plugins: [
         new SriPlugin({ hashFuncNames: ['sha256'], enabled: false })
@@ -206,6 +225,41 @@ describe('webpack-subresource-integrity', function describe() {
       cleanup(err);
     });
   });
+
+  it('should error when code splitting is used with crossOriginLoading', function it(callback) {
+    var tmpDir = tmp.dirSync();
+    function cleanup(err) {
+      fs.unlinkSync(path.join(tmpDir.name, 'bundle.js'));
+      try {
+        fs.unlinkSync(path.join(tmpDir.name, '0.bundle.js'));
+      } catch (e) {
+        fs.unlinkSync(path.join(tmpDir.name, '1.bundle.js'));
+      }
+      tmpDir.removeCallback();
+      callback(err);
+    }
+    var webpackConfig = {
+      entry: path.join(__dirname, './chunk1.js'),
+      output: {
+        path: tmpDir.name,
+        filename: 'bundle.js'
+      },
+      plugins: [
+        new SriPlugin({ hashFuncNames: ['sha256', 'sha384'] })
+      ]
+    };
+    webpack(webpackConfig, function webpackCallback(err, result) {
+      expect(result.compilation.warnings.length).toEqual(1);
+      expect(result.compilation.warnings[0]).toBeAn(Error);
+      expect(result.compilation.warnings[0].message).toMatch(
+          /Set webpack option output.crossOriginLoading when using this plugin/);
+      expect(result.compilation.errors.length).toEqual(1);
+      expect(result.compilation.errors[0]).toBeAn(Error);
+      expect(result.compilation.errors[0].message).toMatch(
+          /webpack option output.crossOriginLoading not set, code splitting will not work!/);
+      cleanup(err);
+    });
+  });
 });
 
 describe('plugin options', function describe() {
@@ -213,7 +267,7 @@ describe('plugin options', function describe() {
     var plugin = new SriPlugin('sha256');
     expect(plugin.options.hashFuncNames).toEqual(['sha256']);
     expect(plugin.options.deprecatedOptions).toBeTruthy();
-    var dummyCompilation = { warnings: [], errors: [] };
+    var dummyCompilation = testCompilation();
     plugin.validateOptions(dummyCompilation);
     expect(dummyCompilation.errors.length).toBe(0);
     expect(dummyCompilation.warnings.length).toBe(1);
@@ -225,7 +279,7 @@ describe('plugin options', function describe() {
     var plugin = new SriPlugin(['sha256', 'sha384']);
     expect(plugin.options.hashFuncNames).toEqual(['sha256', 'sha384']);
     expect(plugin.options.deprecatedOptions).toBeTruthy();
-    var dummyCompilation = { warnings: [], errors: [] };
+    var dummyCompilation = testCompilation();
     plugin.validateOptions(dummyCompilation);
     expect(dummyCompilation.errors.length).toBe(0);
     expect(dummyCompilation.warnings.length).toBe(1);
@@ -239,7 +293,7 @@ describe('plugin options', function describe() {
     });
     expect(plugin.options.hashFuncNames).toEqual(['sha256', 'sha384']);
     expect(plugin.options.deprecatedOptions).toBeFalsy();
-    var dummyCompilation = { warnings: [], errors: [] };
+    var dummyCompilation = testCompilation();
     plugin.validateOptions(dummyCompilation);
     expect(dummyCompilation.errors.length).toBe(0);
     expect(dummyCompilation.warnings.length).toBe(0);
@@ -249,7 +303,7 @@ describe('plugin options', function describe() {
     var plugin = new SriPlugin({
       hashFuncNames: 'sha256'
     });
-    var dummyCompilation = { warnings: [], errors: [] };
+    var dummyCompilation = testCompilation();
     plugin.validateOptions(dummyCompilation);
     expect(dummyCompilation.errors.length).toBe(1);
     expect(dummyCompilation.warnings.length).toBe(0);
@@ -262,7 +316,7 @@ describe('plugin options', function describe() {
     var plugin = new SriPlugin({
       hashFuncNames: [1234]
     });
-    var dummyCompilation = { warnings: [], errors: [] };
+    var dummyCompilation = testCompilation();
     plugin.validateOptions(dummyCompilation);
     expect(dummyCompilation.errors.length).toBe(1);
     expect(dummyCompilation.warnings.length).toBe(0);
@@ -275,7 +329,7 @@ describe('plugin options', function describe() {
     var plugin = new SriPlugin({
       hashFuncNames: ['frobnicate']
     });
-    var dummyCompilation = { warnings: [], errors: [] };
+    var dummyCompilation = testCompilation();
     plugin.validateOptions(dummyCompilation);
     expect(dummyCompilation.errors.length).toBe(1);
     expect(dummyCompilation.warnings.length).toBe(0);
@@ -291,12 +345,14 @@ describe('plugin options', function describe() {
     });
     expect(plugin.options.hashFuncNames).toEqual(['sha256']);
     expect(plugin.options.deprecatedOptions).toBeFalsy();
-    var dummyCompilation = { warnings: [], errors: [] };
+    var dummyCompilation = testCompilation();
     plugin.validateOptions(dummyCompilation);
     expect(dummyCompilation.errors.length).toBe(1);
-    expect(dummyCompilation.warnings.length).toBe(0);
+    expect(dummyCompilation.warnings.length).toBe(1);
     expect(dummyCompilation.errors[0].message).toMatch(
         /options.crossorigin must be a string./);
+    expect(dummyCompilation.warnings[0].message).toMatch(
+        /set webpack option output.crossOriginLoading/);
   });
 
   it('warns if the crossorigin attribute is not recognized', function it() {
@@ -307,34 +363,40 @@ describe('plugin options', function describe() {
     expect(plugin.options.hashFuncNames).toEqual(['sha256']);
     expect(plugin.options.crossorigin).toBe('foo');
     expect(plugin.options.deprecatedOptions).toBeFalsy();
-    var dummyCompilation = { warnings: [], errors: [] };
+    var dummyCompilation = testCompilation();
     plugin.validateOptions(dummyCompilation);
     expect(dummyCompilation.errors.length).toBe(0);
-    expect(dummyCompilation.warnings.length).toBe(1);
+    expect(dummyCompilation.warnings.length).toBe(2);
     expect(dummyCompilation.warnings[0].message).toMatch(
+        /set webpack option output.crossOriginLoading/);
+    expect(dummyCompilation.warnings[1].message).toMatch(
         /specified a value for the crossorigin option that is not part of the set of standard values/);
   });
 
-  it('accepts anonymous crossorigin without warning', function it() {
+  it('accepts anonymous crossorigin without warning about standard values', function it() {
     var plugin = new SriPlugin({
       hashFuncNames: ['sha256'],
       crossorigin: 'anonymous'
     });
-    var dummyCompilation = { warnings: [], errors: [] };
+    var dummyCompilation = testCompilation();
     plugin.validateOptions(dummyCompilation);
     expect(dummyCompilation.errors.length).toBe(0);
-    expect(dummyCompilation.warnings.length).toBe(0);
+    expect(dummyCompilation.warnings.length).toBe(1);
+    expect(dummyCompilation.warnings[0].message).toMatch(
+        /set webpack option output.crossOriginLoading/);
   });
 
-  it('accepts use-credentials crossorigin without warning', function it() {
+  it('accepts use-credentials crossorigin without warning about standard values', function it() {
     var plugin = new SriPlugin({
       hashFuncNames: ['sha256'],
       crossorigin: 'use-credentials'
     });
-    var dummyCompilation = { warnings: [], errors: [] };
+    var dummyCompilation = testCompilation();
     plugin.validateOptions(dummyCompilation);
     expect(dummyCompilation.errors.length).toBe(0);
-    expect(dummyCompilation.warnings.length).toBe(0);
+    expect(dummyCompilation.warnings.length).toBe(1);
+    expect(dummyCompilation.warnings[0].message).toMatch(
+        /set webpack option output.crossOriginLoading/);
   });
 
   it('uses default options', function it() {
@@ -342,13 +404,33 @@ describe('plugin options', function describe() {
       hashFuncNames: ['sha256']
     });
     expect(plugin.options.hashFuncNames).toEqual(['sha256']);
-    expect(plugin.options.crossorigin).toBe('anonymous');
     expect(plugin.options.enabled).toBeTruthy();
     expect(plugin.options.deprecatedOptions).toBeFalsy();
-    var dummyCompilation = { warnings: [], errors: [] };
+    var dummyCompilation = testCompilation();
     plugin.validateOptions(dummyCompilation);
+    expect(plugin.options.crossorigin).toBe('anonymous');
     expect(dummyCompilation.errors.length).toBe(0);
     expect(dummyCompilation.warnings.length).toBe(0);
+  });
+
+  it('should warn when output.crossOriginLoading is not set', function it() {
+    var plugin = new SriPlugin({ hashFuncNames: ['sha256'] });
+    var dummyCompilation = {
+      warnings: [],
+      errors: [],
+      compiler: {
+        options: {
+          output: {
+            crossOriginLoading: false
+          }
+        }
+      }
+    };
+    plugin.validateOptions(dummyCompilation);
+    expect(dummyCompilation.errors.length).toBe(0);
+    expect(dummyCompilation.warnings.length).toBe(1);
+    expect(dummyCompilation.warnings[0].message).toMatch(
+        /Set webpack option output.crossOriginLoading when using this plugin/);
   });
 });
 
@@ -365,7 +447,8 @@ describe('html-webpack-plugin', function describe() {
       entry: path.join(__dirname, './a.js'),
       output: {
         path: tmpDir.name,
-        filename: 'bundle.js'
+        filename: 'bundle.js',
+        crossOriginLoading: 'anonymous'
       },
       plugins: [
         new HtmlWebpackPlugin({ favicon: 'test/test.png' }),
@@ -395,7 +478,8 @@ describe('html-webpack-plugin', function describe() {
       entry: path.join(__dirname, './dummy.js'),
       output: {
         path: tmpDir.name,
-        filename: 'bundle.js'
+        filename: 'bundle.js',
+        crossOriginLoading: 'anonymous'
       },
       module: {
         loaders: [
@@ -453,7 +537,8 @@ describe('html-webpack-plugin', function describe() {
       entry: path.join(__dirname, './dummy.js'),
       output: {
         path: tmpDir.name,
-        filename: 'bundle.js'
+        filename: 'bundle.js',
+        crossOriginLoading: 'anonymous'
       },
       plugins: [
         new HtmlWebpackPlugin(),
@@ -497,7 +582,8 @@ describe('html-webpack-plugin', function describe() {
       entry: path.join(__dirname, './dummy.js'),
       output: {
         path: tmpDir.name,
-        filename: 'subdir/bundle.js'
+        filename: 'subdir/bundle.js',
+        crossOriginLoading: 'anonymous'
       },
       plugins: [
         new HtmlWebpackPlugin({
@@ -535,6 +621,41 @@ describe('html-webpack-plugin', function describe() {
     });
   });
 
+  it('should warn when calling htmlWebpackPlugin.options.sriCrossOrigin', function it(callback) {
+    var tmpDir = tmp.dirSync();
+    var indexEjs = path.join(tmpDir.name, 'index.ejs');
+    function cleanup(err) {
+      fs.unlinkSync(indexEjs);
+      fs.unlinkSync(path.join(tmpDir.name, 'bundle.js'));
+      fs.unlinkSync(path.join(tmpDir.name, 'index.html'));
+      tmpDir.removeCallback();
+      callback(err);
+    }
+    fs.writeFileSync(indexEjs, '<% htmlWebpackPlugin.options.sriCrossOrigin  %>');
+    var webpackConfig = {
+      entry: path.join(__dirname, './dummy.js'),
+      output: {
+        filename: 'bundle.js',
+        path: tmpDir.name,
+        crossOriginLoading: 'anonymous'
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          template: indexEjs
+        }),
+        new SriPlugin({ hashFuncNames: ['sha256', 'sha384'] })
+      ]
+    };
+    webpack(webpackConfig, function webpackCallback(err, result) {
+      expect(result.compilation.warnings.length).toEqual(1);
+      expect(result.compilation.warnings[0]).toBeAn(Error);
+      expect(result.compilation.warnings[0].message).toEqual(
+        'webpack-subresource-integrity: htmlWebpackPlugin.options.sriCrossOrigin is deprecated, use webpackConfig.output.crossOriginLoading instead.'
+      );
+      cleanup(err);
+    });
+  });
+
   it('should work with subdirectories and a custom template', function it(callback) {
     var tmpDir = tmp.dirSync();
     function cleanup() {
@@ -548,7 +669,8 @@ describe('html-webpack-plugin', function describe() {
       entry: path.join(__dirname, './dummy.js'),
       output: {
         path: tmpDir.name,
-        filename: 'subdir/bundle.js'
+        filename: 'subdir/bundle.js',
+        crossOriginLoading: 'anonymous'
       },
       module: {
         loaders: [
@@ -613,7 +735,8 @@ describe('html-webpack-plugin', function describe() {
       output: {
         path: tmpDir.name,
         filename: 'bundle.js',
-        publicPath: '/'
+        publicPath: '/',
+        crossOriginLoading: 'anonymous'
       },
       plugins: [
         new HtmlWebpackPlugin(),
@@ -665,7 +788,8 @@ describe('html-webpack-plugin', function describe() {
       output: {
         path: subDir,
         filename: 'bundle.js',
-        publicPath: '/'
+        publicPath: '/',
+        crossOriginLoading: 'anonymous'
       },
       plugins: [
         new HtmlWebpackPlugin({


### PR DESCRIPTION
- Default crossorigin option to webpack output.crossOriginLoading
- Warn when crossorigin option is passed
- Warn when output.crossOriginLoading is not set
- Error when output.crossOriginLoading is not set and code splitting is
  used

Closes #20