### PR TITLE
Fix a crash on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,10 @@ SubresourceIntegrityPlugin.prototype.validateOptions = function validateOptions(
  *  into `compilation.assets`.
  */
 SubresourceIntegrityPlugin.prototype.hwpAssetPath = function hwpAssetPath(src) {
-  return path.relative(this.hwpPublicPath, src.replace(/\?[a-zA-Z0-9]+$/, ''));
+  return path
+    .relative(this.hwpPublicPath, src.replace(/\?[a-zA-Z0-9]+$/, ''))
+    .split(path.sep)
+    .join('/');
 };
 
 SubresourceIntegrityPlugin.prototype.apply = function apply(compiler) {


### PR DESCRIPTION
Fixes #22.

The return value was containing platform-specific separators but Webpack uses `/`-formatted paths as keys for compilation assets.

I verified it works by running the build both on Windows and on OS X.
It used to fail on Windows but now it doesn't.