### PR TITLE
Remove compatibility with Webpack 2 release candidates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
   firefox: latest
 env:
   - WEBPACK_SUFFIX="@1" ETWP_SUFFIX="@1"
-  - WEBPACK_SUFFIX="@>=2.2.0-rc <3.0" ETWP_SUFFIX="@>=2.0.0-beta <3.0"
+  - WEBPACK_SUFFIX="@2" ETWP_SUFFIX="@2"
 install:
   - npm install --ignore-scripts
   - npm rm webpack

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,26 +5,26 @@ environment:
       WEBPACK_SUFFIX: "@1"
       ETWP_SUFFIX: "@1"
     - nodejs_version: 4
-      WEBPACK_SUFFIX: "@>=2.2.0-rc <3.0"
-      ETWP_SUFFIX: "@>=2.0.0-beta <3.0"
+      WEBPACK_SUFFIX: "@2"
+      ETWP_SUFFIX: "@2"
     - nodejs_version: 5
       WEBPACK_SUFFIX: "@1"
       ETWP_SUFFIX: "@1"
     - nodejs_version: 5
-      WEBPACK_SUFFIX: "@>=2.2.0-rc <3.0"
-      ETWP_SUFFIX: "@>=2.0.0-beta <3.0"
+      WEBPACK_SUFFIX: "@2"
+      ETWP_SUFFIX: "@2"
     - nodejs_version: 6
       WEBPACK_SUFFIX: "@1"
       ETWP_SUFFIX: "@1"
     - nodejs_version: 6
-      WEBPACK_SUFFIX: "@>=2.2.0-rc <3.0"
-      ETWP_SUFFIX: "@>=2.0.0-beta <3.0"
+      WEBPACK_SUFFIX: "@2"
+      ETWP_SUFFIX: "@2"
     - nodejs_version: 7
       WEBPACK_SUFFIX: "@1"
       ETWP_SUFFIX: "@1"
     - nodejs_version: 7
-      WEBPACK_SUFFIX: "@>=2.2.0-rc <3.0"
-      ETWP_SUFFIX: "@>=2.0.0-beta <3.0"
+      WEBPACK_SUFFIX: "@2"
+      ETWP_SUFFIX: "@2"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -82,7 +82,6 @@ module.exports = function karmaConfig(config) {
       'karma-mocha'
     ],
     webpack: {
-      entry: 'main',
       output: {
         crossOriginLoading: 'anonymous'
       },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "webpack": "^1.12.11"
   },
   "peerDependencies": {
-    "webpack": "^1.12.11 || >=2.1.0-beta || >=2.2.0-rc <3.0"
+    "webpack": "^1.12.11 || ~2"
   },
   "files": [
     "LICENSE",

--- a/test/test-webpack.js
+++ b/test/test-webpack.js
@@ -18,7 +18,7 @@ function createExtractTextLoader() {
     return ExtractTextPlugin.extract('style-loader', 'css-loader');
   }
   // extract-text-webpack-plugin 2.x
-  return ExtractTextPlugin.extract({ fallbackLoader: 'style-loader', loader: 'css-loader' });
+  return ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' });
 }
 
 function testCompilation() {


### PR DESCRIPTION
Also, use extract-text-webpack-plugin 2 production releases for
testing.