### PR TITLE
Webpack Watch Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -373,6 +373,8 @@ SubresourceIntegrityPlugin.prototype.apply = function apply(compiler) {
               return compilation.assets[src].integrity;
             });
         });
+        
+        if(typeof pluginArgs.plugin.options.sriCrossOrigin === 'undefined')
         Object.defineProperty(
           pluginArgs.plugin.options, 'sriCrossOrigin', {
             get: function get() {


### PR DESCRIPTION
When running with Webpack watch option, the first time works, but the second one I'm getting this error:

ERROR in   TypeError: Cannot redefine property: sriCrossOrigin
  
  - Function.defineProperty
  
  - index.js:365 Compilation.beforeHtmlGeneration
    [cv-app-payment]/[webpack-subresource-integrity]/index.js:365:16
  
  - Tapable.js:208 Compilation.applyPluginsAsyncWaterfall
    [cv-app-payment]/[tapable]/lib/Tapable.js:208:13

[...]

Fixing declaring class if already exists.