### PR TITLE
fix peerDependencies for webpack 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-subresource-integrity",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Webpack plugin for enabling Subresource Integrity",
   "engines": {
     "node": ">=4"
@@ -59,7 +59,7 @@
     "webpack": "^1.12.11"
   },
   "peerDependencies": {
-    "webpack": "^1.12.11 || ~2"
+    "webpack": "^1.12.11 || ~2 || ~3"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
package.json currently specifies peer dependency for webpack at 1.x or 2.x, causing NPM warnings when used with 3.x; this patch adds webpack 3.x as a permissible peer dependency