### PR TITLE
#22 Fixed TypeError 'integrity' of undefined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,7 +323,7 @@ SubresourceIntegrityPlugin.prototype.apply = function apply(compiler) {
           pluginArgs.assets[fileType + 'Integrity'] =
             pluginArgs.assets[fileType].map(function assetIntegrity(filePath) {
               var src = self.hwpAssetPath(filePath);
-              return compilation.assets[src].integrity;
+              return src in compilation.assets ? compilation.assets[src].integrity : false;
             });
         });
         callback(null, pluginArgs);


### PR DESCRIPTION
In some instances, the src is not found from the compilation.assets array causing a build error. This occures at least with css files.
This fix allows to skip these items that produces a correct warning of:  Cannot determine hash for asset 'css/app.xxxxxxx.css', the resource will be unprotected.