### PR TITLE
Fix invalid JavaScript generation with certain named chunk IDs

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,13 +55,12 @@ WebIntegrityJsonpMainTemplatePlugin.prototype.apply = function apply(mainTemplat
 
       return this.asString([
         source,
-        'var sriHashes = {',
-        this.indent(
-          Object.keys(allDepChunkIds).map(function mapChunkId(chunkId) {
-            return chunkId + ':"' + makePlaceholder(chunkId) + '"';
-          }).join(',\n')
-        ),
-        '};'
+        'var sriHashes = ' + JSON.stringify(
+          Object.keys(allDepChunkIds).reduce(function chunkIdReducer(sriHashes, chunkId) {
+            sriHashes[chunkId] = makePlaceholder(chunkId);
+            return sriHashes;
+          }, {})
+        ) + ';'
       ]);
     }
     return source;


### PR DESCRIPTION
Chunks named "chunk-1" etc. causes a syntax error in the generated code. This fixes it.