### PR TITLE
support integration with webpack-plugin-hash-output

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ SubresourceIntegrityPlugin.prototype.apply = function apply(compiler) {
   }
 
   compiler.plugin('after-plugins', function afterPlugins() {
-    compiler.plugin('this-compilation', function thisCompilation(compilation) {
+    compiler.plugin('compilation', function thisCompilation(compilation) {
       self.validateOptions(compilation);
 
       if (!self.options.enabled) {


### PR DESCRIPTION
Hi, this adds support for integration with plugins (like the [webpack-plugin-hash-output](https://github.com/scinos/webpack-plugin-hash-output)) that has to run last as well and can change the manifest files output.

Basically, it makes this plugin to work while still supporting long term caching (there is discussion [here](https://github.com/webpack/webpack/issues/4659)).

The current integration is broken because the [webpack-plugin-hash-output](https://github.com/scinos/webpack-plugin-hash-output) plugin runs after this plugin (because it listens to the `compilation` hook which invokes after `this-compilation` as [can be seen here](https://webpack.js.org/api/compiler/#event-hooks)):
* sub resource integrity is wrong because the content of files is being changed by the [webpack-plugin-hash-output](https://github.com/scinos/webpack-plugin-hash-output) plugin after the hash calculation.

In order to fix it, there is need to:
1. make this plugin listen on the `compilation` hook so it can run after the `webpack-plugin-hash-output` plugin (and all others) -> this way the hashes of all sub resources will be correct. This PR address it.
2. since now this plugin runs after the `webpack-plugin-hash-output` plugin and edits only the manifest files, there is need to run the `webpack-plugin-hash-output` plugin again only for the manifest files in order to recalculate the filenames to be based on the updated content => I submitted [this PR](https://github.com/scinos/webpack-plugin-hash-output/pull/9).