### PR TITLE
feat: add sri to assets copied with CopyWebpackPlugin

### DIFF
--- a/examples/copy-plugin-assets/README.md
+++ b/examples/copy-plugin-assets/README.md
@@ -1,0 +1,3 @@
+# With CopyWebpackPlugin
+
+Testing if intergrity hash is added for asets copied with `webpack-copy-file` plugin.

--- a/examples/copy-plugin-assets/asset.txt
+++ b/examples/copy-plugin-assets/asset.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolore asset

--- a/examples/copy-plugin-assets/test.js
+++ b/examples/copy-plugin-assets/test.js
@@ -1,0 +1,14 @@
+var expect = require('expect');
+var webpackVersion = Number(
+  require('webpack/package.json').version.split('.')[0]
+);
+
+module.exports.skip = function skip() {
+  return webpackVersion < 4;
+};
+
+module.exports.check = function check(stats) {
+  expect(stats.compilation.assets['asset_copy.txt'].integrity).toEqual(
+    'sha256-wibhg9oz2c6SWYeRXr5Gm41ZEMI2cTMnzXY6XvKESaI= sha384-qT+SO7B2fXBg/6LmmCLeaJWxIetW8W1rbbgh0dXt/zvt9biphdWNCBfg/nyrsT2m'
+  );
+};

--- a/examples/copy-plugin-assets/webpack.config.js
+++ b/examples/copy-plugin-assets/webpack.config.js
@@ -1,0 +1,23 @@
+var SriPlugin = require('webpack-subresource-integrity');
+var CopyWebpackPlugin = require('copy-webpack-plugin');
+
+module.exports = {
+  entry: {
+    index: './index.js'
+  },
+  output: {
+    crossOriginLoading: 'anonymous'
+  },
+  plugins: [
+    new SriPlugin({
+      hashFuncNames: ['sha256', 'sha384'],
+      enabled: true
+    }),
+    new CopyWebpackPlugin([
+      {
+        from: 'asset.txt',
+        to: 'asset_copy.txt'
+      }
+    ])
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-eslint": "^8.2.1",
     "bluebird": "^3.5.1",
     "check-node-version": "^3.2.0",
+    "copy-webpack-plugin": "^4.5.1",
     "connect": "^3.6.6",
     "coveralls": "^3.0.0",
     "css-loader": "^0.28.0",


### PR DESCRIPTION
Add SRI integrity hash to files copied with the `copy-webpack-plugin`. Basically it does an extra run on the emit hook after the copy plugin copies the files. 