### PR TITLE
Add JSON mapping file

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,3 +10,7 @@ exclude_paths:
   - test/
   - examples/
   - karma.conf.js
+checks:
+  method-complexity:
+    config:
+      threshold: 6

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ coverage
 # node-waf configuration
 .lock-wscript
 
+# MacOS filesystem
+.DS_Store
+
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ manipulation.
 ## Features
 
 - Optional integration with [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin)
+- Optional JSON manifest mapping filenames to integrity hashes
 - Automatic support for code splitting (integrity for lazy-loaded chunks)
 - Compatible with Webpack 1.x, 2.x, 3.x and 4.x
 
@@ -122,6 +123,15 @@ Default value: `true`
 When this value is falsy, the plugin doesn't run and no integrity
 values are calculated. It is recommended to disable the plugin in
 development mode.
+
+#### jsonFile
+
+Default value: `null`
+
+When assigned a JSON filename (ex: `integrity.json`), a JSON file
+of the given name will be added to the Webpack build with a mapping
+of asset filenames to their integrity hashes. Load this file into
+other applications to generate tags with integrity attributes.
 
 ## Caveats
 

--- a/examples/json-file/README.md
+++ b/examples/json-file/README.md
@@ -1,0 +1,4 @@
+# JSON File
+
+Simple example showing that webpack-subresource-integrity will
+generate a JSON file mapping file names to integrity hashes.

--- a/examples/json-file/test.js
+++ b/examples/json-file/test.js
@@ -1,0 +1,10 @@
+var expect = require('expect');
+
+module.exports.check = function check(stats) {
+  var json = stats.compilation.assets['integrity.json']
+  expect(typeof json).toBe('object');
+
+  json = JSON.parse(json.source());
+  expect(typeof json).toBe('object');
+  expect(json['bundle.js']).toBe(stats.compilation.assets['bundle.js'].integrity);
+};

--- a/examples/json-file/webpack.config.js
+++ b/examples/json-file/webpack.config.js
@@ -1,0 +1,15 @@
+var SriPlugin = require('webpack-subresource-integrity');
+var webpackVersion = Number(
+  require('webpack/package.json').version.split('.')[0]
+);
+
+module.exports = {
+  entry: './index.js',
+  output: {
+    crossOriginLoading: 'anonymous',
+    filename: 'bundle.js'
+  },
+  plugins: [
+    new SriPlugin({ hashFuncNames: ['sha256'], jsonFile: 'integrity.json' })
+  ]
+};

--- a/index.js
+++ b/index.js
@@ -280,6 +280,7 @@ SubresourceIntegrityPlugin.prototype.jsonFile = function jsonFile(compilation, c
 
   json = JSON.stringify(json, null, 2);
 
+  // eslint-disable-next-line no-param-reassign
   compilation.assets[this.options.jsonFile] = {
     source: function source() { return json; },
     size:   function size() { return json.length; }

--- a/index.js
+++ b/index.js
@@ -269,19 +269,20 @@ SubresourceIntegrityPlugin.prototype.alterAssetTags =
 *  Asset filenames are mapped to their integrity hash.
 */
 SubresourceIntegrityPlugin.prototype.jsonFile = function jsonFile(compilation, callback) {
-  var json = Object.keys(compilation.assets).reduce(function(memo, assetName) {
+  var json = {};
+
+  Object.keys(compilation.assets).forEach(function addJsonAsset(assetName) {
     var asset = compilation.assets[assetName];
     if (asset.integrity) {
-      memo[assetName] = asset.integrity
+      json[assetName] = asset.integrity;
     }
-    return memo;
-  }, {});
+  });
 
   json = JSON.stringify(json, null, 2);
 
   compilation.assets[this.options.jsonFile] = {
-    source: function() { return json; },
-    size:   function() { return json.length; }
+    source: function source() { return json; },
+    size:   function size() { return json.length; }
   };
 
   callback();

--- a/test/test-misc.js
+++ b/test/test-misc.js
@@ -283,6 +283,7 @@ describe('Plugin Options', function describe() {
         /Cannot use hash function 'frobnicate': Digest method not supported/);
     expect(plugin.options.enabled).toBeFalsy();
   });
+
   it('uses default options', function it() {
     var plugin = new SriPlugin({
       hashFuncNames: ['sha256']

--- a/test/test-misc.js
+++ b/test/test-misc.js
@@ -227,6 +227,12 @@ describe('Plugin Options', function describe() {
         'the set for which support is mandated by the specification'));
   });
 
+  it('warns when jsonFile is not a valid filename', function it() {
+    expect(function block() {
+      new SriPlugin({ jsonFile: 'integrity.js' }); // eslint-disable-line no-new
+    }).toThrow(/jsonFile must specify a \.json filename/);
+  });
+
   it('supports new constructor with array of hash function names', function it() {
     var plugin = new SriPlugin({
       hashFuncNames: ['sha256', 'sha384']
@@ -277,7 +283,6 @@ describe('Plugin Options', function describe() {
         /Cannot use hash function 'frobnicate': Digest method not supported/);
     expect(plugin.options.enabled).toBeFalsy();
   });
-
   it('uses default options', function it() {
     var plugin = new SriPlugin({
       hashFuncNames: ['sha256']


### PR DESCRIPTION
This adds a `jsonFile` option. When provided, a JSON file of the given name (ex: `integrity.json`) will be added to the Webpack build containing a mapping of asset filenames to their integrity hashes.

This feature allows other applications to load up the mapping of SRI hashes for use while generating asset tags.