### PR TITLE
Revert "Merge pull request #85 from waysact/safe-require"

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,11 +10,19 @@ var path = require('path');
 var ReplaceSource = require('webpack-core/lib/ReplaceSource');
 var util = require('./util');
 var WebIntegrityJsonpMainTemplatePlugin = require('./jmtp');
-var safeRequire = require('safe-require');
-var HtmlWebpackPlugin = safeRequire('html-webpack-plugin');
+var HtmlWebpackPlugin;
 
 // https://www.w3.org/TR/2016/REC-SRI-20160623/#cryptographic-hash-functions
 var standardHashFuncNames = ['sha256', 'sha384', 'sha512'];
+
+try {
+  // eslint-disable-next-line global-require
+  HtmlWebpackPlugin = require('html-webpack-plugin');
+} catch (e) {
+  if (!(e instanceof Error) || e.code !== 'MODULE_NOT_FOUND') {
+    throw e;
+  }
+}
 
 function SubresourceIntegrityPlugin(options) {
   var useOptions;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "homepage": "https://github.com/waysact/webpack-subresource-integrity#readme",
   "dependencies": {
-    "safe-require": "^1.0.3",
     "webpack-core": "^0.6.8"
   },
   "devDependencies": {


### PR DESCRIPTION
On second thought the change in #85 introduces the first non-essential
run-time dependency which, for a small piece of code like this,
doesn't seem to be worth it.  I'd rather keep run-time dependencies
limited to the essentials, especially when the extra dependency
doesn't save more than a couple of lines of code.

This reverts commit ad1bfab96efb615cd3800d0814653ad22a8c84ac, reversing
changes made to 488459a043a6d9347222168306b8ab55c40c4743.