### PR TITLE
Fix sourcemap in projects with code splitting

### DIFF
--- a/examples/sourcemap-code-splitting/1.js
+++ b/examples/sourcemap-code-splitting/1.js
@@ -1,0 +1,3 @@
+export default {
+  chunk: 1,
+};

--- a/examples/sourcemap-code-splitting/2.js
+++ b/examples/sourcemap-code-splitting/2.js
@@ -1,0 +1,3 @@
+export default {
+  chunk: 2,
+};

--- a/examples/sourcemap-code-splitting/README.md
+++ b/examples/sourcemap-code-splitting/README.md
@@ -1,0 +1,3 @@
+# Sourcemap and code splitting
+
+Test case for sourcemap and code splitting

--- a/examples/sourcemap-code-splitting/index.js
+++ b/examples/sourcemap-code-splitting/index.js
@@ -1,0 +1,3 @@
+import('./1.js');
+import('./2.js');
+console.log('ok');

--- a/examples/sourcemap-code-splitting/test.js
+++ b/examples/sourcemap-code-splitting/test.js
@@ -9,9 +9,9 @@ module.exports.skip = function skip() {
 };
 
 module.exports.check = function check() {
-  var findAndStripSriHashString = function(filePath, pattern, offset = 0) {
+  var findAndStripSriHashString = function(filePath, pattern, offset) {
     var fileContent = fs.readFileSync(path.join(__dirname, filePath), 'utf-8');
-    var string = fileContent.substring(fileContent.indexOf(pattern) + offset)
+    var string = fileContent.substring(fileContent.indexOf(pattern) + (offset || 0))
         .match(/\{(.*?)\}/)[0].replace(/\\/g, '').replace(/\"/g, '');
     return string;
   }

--- a/examples/sourcemap-code-splitting/test.js
+++ b/examples/sourcemap-code-splitting/test.js
@@ -1,0 +1,22 @@
+var expect = require('expect');
+var fs = require('fs');
+var path = require('path');
+
+var webpackVersion = Number(require('webpack/package.json').version.split('.')[0]);
+
+module.exports.skip = function skip() {
+  return webpackVersion < 2;
+};
+
+module.exports.check = function check() {
+  var findAndStripSriHashString = function(filePath, pattern, offset = 0) {
+    var fileContent = fs.readFileSync(path.join(__dirname, filePath), 'utf-8');
+    var string = fileContent.substring(fileContent.indexOf(pattern) + offset)
+        .match(/\{(.*?)\}/)[0].replace(/\\/g, '').replace(/\"/g, '');
+    return string;
+  }
+
+  var sriHashesInSource = findAndStripSriHashString('dist/index.js', 'sha256-', -10);
+  var sriHashesInMap = findAndStripSriHashString('dist/index.js.map', 'var sriHashes = ');
+  expect(sriHashesInSource.length).toEqual(sriHashesInMap.length);
+};

--- a/examples/sourcemap-code-splitting/webpack.config.js
+++ b/examples/sourcemap-code-splitting/webpack.config.js
@@ -1,0 +1,19 @@
+var SriPlugin = require('webpack-subresource-integrity');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: {
+    index: './index.js'
+  },
+  output: {
+    crossOriginLoading: 'anonymous'
+  },
+  devtool: 'source-map',
+  plugins: [
+    new SriPlugin({
+      hashFuncNames: ['sha256', 'sha384'],
+      enabled: true
+    }),
+    new HtmlWebpackPlugin()
+  ]
+};

--- a/index.js
+++ b/index.js
@@ -249,15 +249,15 @@ SubresourceIntegrityPlugin.prototype.addMissingIntegrityHashes =
  *  Calculate SRI values for each chunk and replace the magic
  *  placeholders by the actual values.
  */
-SubresourceIntegrityPlugin.prototype.afterOptimizeAssets =
-  function afterOptimizeAssets(compilation, assets) {
+SubresourceIntegrityPlugin.prototype.afterOptimizeChunkAssets =
+  function afterOptimizeChunkAssets(compilation, chunks) {
     var self = this;
 
-    compilation.chunks.filter(util.isRuntimeChunk).forEach(function forEachChunk(chunk) {
-      self.processChunk(chunk, compilation, assets);
+    chunks.filter(util.isRuntimeChunk).forEach(function forEachChunk(chunk) {
+      self.processChunk(chunk, compilation, compilation.assets);
     });
 
-    this.addMissingIntegrityHashes(assets);
+    this.addMissingIntegrityHashes(compilation.assets);
   };
 
 SubresourceIntegrityPlugin.prototype.processTag =
@@ -342,7 +342,7 @@ SubresourceIntegrityPlugin.prototype.registerHwpHooks =
 
 SubresourceIntegrityPlugin.prototype.thisCompilation =
   function thisCompilation(compiler, compilation) {
-    var afterOptimizeAssets = this.afterOptimizeAssets.bind(this, compilation);
+    var afterOptimizeChunkAssets = this.afterOptimizeChunkAssets.bind(this, compilation);
     var chunkAsset = this.chunkAsset.bind(this, compilation);
     var alterAssetTags = this.alterAssetTags.bind(this, compilation);
     var beforeHtmlGeneration = this.beforeHtmlGeneration.bind(this, compilation);
@@ -364,11 +364,11 @@ SubresourceIntegrityPlugin.prototype.thisCompilation =
      *    Modify the asset tags before webpack injects them for anything with an integrity value.
      */
     if (compiler.hooks) {
-      compilation.hooks.afterOptimizeAssets.tap('SriPlugin', afterOptimizeAssets);
+      compilation.hooks.afterOptimizeChunkAssets.tap('SriPlugin', afterOptimizeChunkAssets);
       compilation.hooks.chunkAsset.tap('SriPlugin', chunkAsset);
       compiler.hooks.compilation.tap('HtmlWebpackPluginHooks', this.registerHwpHooks.bind(this, alterAssetTags, beforeHtmlGeneration));
     } else {
-      compilation.plugin('after-optimize-assets', afterOptimizeAssets);
+      compilation.plugin('after-optimize-chunk-assets', afterOptimizeChunkAssets);
       compilation.plugin('chunk-asset', chunkAsset);
       compilation.plugin('html-webpack-plugin-alter-asset-tags', alterAssetTags);
       compilation.plugin('html-webpack-plugin-before-html-generation', beforeHtmlGeneration);

--- a/jmtp.js
+++ b/jmtp.js
@@ -17,6 +17,7 @@ WebIntegrityJsonpMainTemplatePlugin.prototype.addSriHashes =
   function addSriHashes(mainTemplate, source, chunk) {
     var allChunks = util.findChunks(chunk);
     var includedChunks = chunk.getChunkMaps().hash;
+    var hashFuncNames = this.sriPlugin.options.hashFuncNames;
 
     if (allChunks.size > 0) {
       return (Template.asString || mainTemplate.asString)([
@@ -29,7 +30,7 @@ WebIntegrityJsonpMainTemplatePlugin.prototype.addSriHashes =
             ) {
               if (includedChunks[depChunk.id.toString()]) {
                 // eslint-disable-next-line no-param-reassign
-                sriHashes[depChunk.id] = util.makePlaceholder(depChunk.id);
+                sriHashes[depChunk.id] = util.makePlaceholder(hashFuncNames, depChunk.id);
               }
               return sriHashes;
             },

--- a/util.js
+++ b/util.js
@@ -98,8 +98,9 @@ function isRuntimeChunk(chunk) {
   return "hasRuntime" in chunk ? chunk.hasRuntime() : chunk.entry;
 }
 
-function makePlaceholder(id) {
-  return "*-*-*-CHUNK-SRI-HASH-" + id + "-*-*-*";
+function makePlaceholder(hashFuncNames, id) {
+  var placeholder = "*-*-*-CHUNK-SRI-HASH-" + id + "-*-*-*";
+  return computeIntegrity(hashFuncNames, placeholder);
 }
 
 module.exports.computeIntegrity = computeIntegrity;


### PR DESCRIPTION
We’ve noticed an issue when using this plugin in projects with code splitting. Basically there are [placeholders](https://github.com/waysact/webpack-subresource-integrity/blob/1c2084fa2cb908b6ee2e6e1d332e1ec75903a84f/util.js#L101) of SRI hashes being added to js binary, which are later [replaced](https://github.com/waysact/webpack-subresource-integrity/blob/1c2084fa2cb908b6ee2e6e1d332e1ec75903a84f/index.js#L178-L187) with real hash values. However, the placeholders in sourcemap files are not updated, so there could be a mismatch between the source code and sourcemap after where the variable of `sriHashes` is [injected](https://github.com/waysact/webpack-subresource-integrity/blob/d2b0563a277f4149e5df8f2a83b2473d0c2f51d3/jmtp.js#L24). 
![image](https://user-images.githubusercontent.com/8864469/62658909-c6625000-b91e-11e9-8d52-acf45a406ca6.png)

The cause is probably because the function of `processChunk` (which calls `replaceAsset`) is tapped to `afterOptimizeAssets` hook, while in webpack, the plugin that actually generates sourcemap is [tapped](https://github.com/webpack/webpack/blob/2fb853ee03044372a3b73d16675438f06565d048/lib/SourceMapDevToolPlugin.js#L156) to `afterOptimizeChunkAssets` hook. Probably in projects that don’t use code splitting, the two hooks happen at the same time, but in projects with code splitting, `afterOptimizeChunkAssets` happens before `afterOptimizeAssets`, so `sriHashes` replacement could break the sourcemap which was generated before that. 

Changing the hook looks like fixing the issue.
![image](https://user-images.githubusercontent.com/8864469/62659182-8485d980-b91f-11e9-94aa-ace8fde84af9.png)
