### PR TITLE
Ignore assets removed by other plugins

### DIFF
--- a/examples/webpack-fix-style-only-entries/README.md
+++ b/examples/webpack-fix-style-only-entries/README.md
@@ -1,0 +1,3 @@
+# With webpack-fix-style-only-entries
+
+Test case for issue #106

--- a/examples/webpack-fix-style-only-entries/index.js
+++ b/examples/webpack-fix-style-only-entries/index.js
@@ -1,0 +1,1 @@
+console.log('ok');

--- a/examples/webpack-fix-style-only-entries/test.js
+++ b/examples/webpack-fix-style-only-entries/test.js
@@ -1,0 +1,13 @@
+var expect = require('expect');
+var fs = require('fs');
+var path = require('path');
+
+var webpackVersion = Number(require('webpack/package.json').version.split('.')[0]);
+
+module.exports.skip = function skip() {
+  return webpackVersion < 4;
+};
+
+module.exports.check = function check(stats) {
+  expect(stats.compilation.warnings.length).toEqual(0);
+};

--- a/examples/webpack-fix-style-only-entries/webpack.config.js
+++ b/examples/webpack-fix-style-only-entries/webpack.config.js
@@ -1,0 +1,43 @@
+var SriPlugin = require('webpack-subresource-integrity');
+var MiniCssExtractPlugin = require('mini-css-extract-plugin');
+var WebpackAssetsManifest = require('webpack-assets-manifest');
+var FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
+
+module.exports = {
+  entry: {
+    index: './index.js',
+    style: ["./style.css"],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              importLoaders: 1
+            }
+          }
+        ]
+      },
+    ],
+  },
+  output: {
+    crossOriginLoading: 'anonymous'
+  },
+  plugins: [
+    new FixStyleOnlyEntriesPlugin({
+      silent: true
+    }),
+    new MiniCssExtractPlugin({
+      filename: "[name].css",
+    }),
+    new WebpackAssetsManifest({integrity: true}),
+    new SriPlugin({
+      hashFuncNames: ['sha256', 'sha384'],
+      enabled: true
+    }),
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "style-loader": "^0.18.0",
     "tmp": "^0.0.31",
     "webpack": "^1.12.11",
-    "webpack-assets-manifest": "^3.0.0"
+    "webpack-assets-manifest": "^3.0.0",
+    "webpack-fix-style-only-entries": "^0.4.0"
   },
   "peerDependencies": {
     "html-webpack-plugin": "^2.21.0 || ~3 || >=4.0.0-alpha.2 <5",


### PR DESCRIPTION
Also, make an effort to ensure our chunkAsset callback runs after
callbacks registered by other plugins.

Closes #106