### PR TITLE
Fix inline script Error

### DIFF
--- a/util.js
+++ b/util.js
@@ -62,7 +62,7 @@ function computeIntegrity(hashFuncNames, source) {
 
 function getTagSrc(tag) {
   // Get asset path - src from scripts and href from links
-  return tag.attributes.href || tag.attributes.src;
+  return tag.attributes && (tag.attributes.href || tag.attributes.src);
 }
 
 function filterTag(tag) {


### PR DESCRIPTION
Inline script tags (which have no attributes) will throw a null reference error, because there's no src or href.

Ie
```html
<script>
console.log('this tag fails')
</script>
```