### PR TITLE
Ignore tags with null attributes

### DIFF
--- a/test/test-misc.js
+++ b/test/test-misc.js
@@ -17,6 +17,8 @@ var webpackVersion = Number(
   require('webpack/package.json').version.split('.')[0]
 );
 
+var util = require('../util');
+
 function testCompilation() {
   return {
     warnings: [],
@@ -310,5 +312,9 @@ describe('Plugin Options', function describe() {
     expect(dummyCompilation.warnings.length).toBe(1);
     expect(dummyCompilation.warnings[0].message).toMatch(
         /Set webpack option output.crossOriginLoading/);
+  });
+
+  it('ignores tags without attributes', function it() {
+    expect(util.filterTag({ tagName: "script" })).toBeFalsy();
   });
 });

--- a/util.js
+++ b/util.js
@@ -67,7 +67,11 @@ function getTagSrc(tag) {
 
 function filterTag(tag) {
   // Process only script and link tags with a url
-  return (tag.tagName === "script" || tag.tagName === "link") && getTagSrc(tag);
+  return (
+    (tag.tagName === "script" || tag.tagName === "link") &&
+    tag.attributes &&
+    getTagSrc(tag)
+  );
 }
 
 function normalizePath(p) {


### PR DESCRIPTION
Fixes an edge case that occurs when used with vue-cli.

Closes #122