### PR TITLE
Do not import webpack

### DIFF
--- a/webpack-subresource-integrity/etc/webpack-subresource-integrity.api.md
+++ b/webpack-subresource-integrity/etc/webpack-subresource-integrity.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { Compiler } from 'webpack';
+import type { Compiler } from 'webpack';
 
 // @public
 export class SubresourceIntegrityPlugin {

--- a/webpack-subresource-integrity/package.json
+++ b/webpack-subresource-integrity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-subresource-integrity",
-  "version": "5.0.0-alpha.2",
+  "version": "5.0.0-alpha.3",
   "description": "Webpack plugin for enabling Subresource Integrity",
   "author": "Julian Scheid <julian@evergiving.com>",
   "license": "MIT",


### PR DESCRIPTION
This change allows using the plugin in environments where the version of webpack applying the plugin is different from the installed version of webpack. This can happen in Next.js 10.0.6 which bundles webpack.
