### PR TITLE
Add test demonstrating effects of plugin order

### DIFF
--- a/examples/plugin-order/README.md
+++ b/examples/plugin-order/README.md
@@ -1,0 +1,4 @@
+# Plugin order
+
+This test asserts that if a plugin modifies an asset after WSI has already run,
+the integrity hash will be incorrect.

--- a/examples/plugin-order/index-orig.js
+++ b/examples/plugin-order/index-orig.js
@@ -1,0 +1,1 @@
+console.log("ok");

--- a/examples/plugin-order/index.js
+++ b/examples/plugin-order/index.js
@@ -1,0 +1,1 @@
+console.log("ok");

--- a/examples/plugin-order/package.json
+++ b/examples/plugin-order/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "plugin-order",
+  "description": "Ensure the order of plugins does affect integrity hashes",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "expect": "^26.6.2",
+    "nyc": "*",
+    "webpack": "^5.44.0",
+    "webpack-cli": "4",
+    "webpack-subresource-integrity": "*"
+  }
+}

--- a/examples/plugin-order/webpack.config.js
+++ b/examples/plugin-order/webpack.config.js
@@ -1,0 +1,71 @@
+const { SubresourceIntegrityPlugin } = require("webpack-subresource-integrity");
+const expect = require("expect");
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+  entry: {
+    index: "./index.js",
+    'index-orig': "./index-orig.js",
+  },
+  output: {
+    crossOriginLoading: "anonymous",
+  },
+  plugins: [
+    new SubresourceIntegrityPlugin({
+      hashFuncNames: ["sha256"],
+      enabled: true,
+    }),
+    // This plugin taps into the same `processAssets` stage as WSI,
+    // and runs after it. It will modify the `index-orig.js` asset
+    // after WSI has calculated its integrity hash, thus producing
+    // an erro scenario. This test asserts that the hash calculation
+    // will be incorect.
+    {
+      apply: (compiler) => {
+        compiler.hooks.thisCompilation.tap(
+          { name: 'edit index.js' },
+          (compilation) => {
+            compilation.hooks.processAssets.tap(
+              {
+                name: 'edit index.js',
+                stage: compilation.compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE,
+              },
+              (records) => {
+                compilation.updateAsset(
+                  'index.js',
+                  new compiler.webpack.sources.RawSource('console.log("not ok");', false)
+                );
+              }
+            );
+          }
+        );
+      }
+    },
+    {
+      apply: (compiler) => {
+        compiler.hooks.done.tap("wsi-test", (stats) => {
+          const origSourceContent = fs.readFileSync(path.join(__dirname, './index-orig.js')).toString()
+          const sourceContent = fs.readFileSync(path.join(__dirname, './index.js')).toString()
+
+          // Source files are identical
+          expect(origSourceContent).toEqual(sourceContent);
+
+          const { assets } = stats.toJson()
+
+          const origIntegrity = assets.find((asset) => asset.name == "index-orig.js").integrity
+          const integrity = assets.find((asset) => asset.name == "index.js").integrity
+          
+          // Integrity is the same between `index.js` and `index-orig.js`
+          expect(integrity).toEqual(origIntegrity);
+
+          const origDistContent = fs.readFileSync(path.join(__dirname, './dist/index-orig.js')).toString()
+          const distContent = fs.readFileSync(path.join(__dirname, './dist/index.js')).toString()
+          
+          // But their contents are not!
+          expect(origDistContent).not.toEqual(distContent);
+        });
+      },
+    },
+  ],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8347,6 +8347,18 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
+"plugin-order@workspace:examples/plugin-order":
+  version: 0.0.0-use.local
+  resolution: "plugin-order@workspace:examples/plugin-order"
+  dependencies:
+    expect: ^26.6.2
+    nyc: "*"
+    webpack: ^5.44.0
+    webpack-cli: 4
+    webpack-subresource-integrity: "*"
+  languageName: unknown
+  linkType: soft
+
 "posix-character-classes@npm:^0.1.0":
   version: 0.1.1
   resolution: "posix-character-classes@npm:0.1.1"


### PR DESCRIPTION
This PR adds a new test demonstrating that if a plugin changes the source of a file after WSI has already calculated its hash, the hash will be incorrect. This is related to https://github.com/waysact/webpack-subresource-integrity/issues/168.

One possible method of fixing this issue might be to use the `additionalAssets: true` setting of the `processAssets` compilation hook, because it will make a plugin run again for assets emitted after the initial run. See the docs for more info: https://webpack.js.org/api/compilation-hooks/#additional-assets