### PR TITLE
Add `lazyHashes` option to define integrity hashes only in direct parents of assets

### DIFF
--- a/examples/hwp-custom-template/webpack.config.js
+++ b/examples/hwp-custom-template/webpack.config.js
@@ -40,14 +40,16 @@ module.exports = {
 
           const jsIntegrity = stats
             .toJson()
-            .assets.find((asset) => asset.name === "subdir/bundle.js")
-            .integrity;
+            .assets.find(
+              (asset) => asset.name === "subdir/bundle.js"
+            ).integrity;
           expect(jsIntegrity).toMatch(/^sha/);
 
           const cssIntegrity = stats
             .toJson()
-            .assets.find((asset) => asset.name === "subdir/styles.css")
-            .integrity;
+            .assets.find(
+              (asset) => asset.name === "subdir/styles.css"
+            ).integrity;
           expect(cssIntegrity).toMatch(/^sha/);
 
           return new Promise((resolve, reject) => {

--- a/examples/lazy-hashes-cycles/1.js
+++ b/examples/lazy-hashes-cycles/1.js
@@ -1,0 +1,5 @@
+import("./2.js");
+import("./leaf.js");
+export default {
+  chunk: 1,
+};

--- a/examples/lazy-hashes-cycles/2.js
+++ b/examples/lazy-hashes-cycles/2.js
@@ -1,0 +1,4 @@
+import("./3.js");
+export default {
+  chunk: 2,
+};

--- a/examples/lazy-hashes-cycles/3.js
+++ b/examples/lazy-hashes-cycles/3.js
@@ -1,0 +1,4 @@
+import("./1.js");
+export default {
+  chunk: 3,
+};

--- a/examples/lazy-hashes-cycles/README.md
+++ b/examples/lazy-hashes-cycles/README.md
@@ -1,3 +1,3 @@
 # Sourcemap and code splitting
 
-Test case for sourcemap and code splitting
+Test case for lazy hashes where there is a chunk dependency cycle

--- a/examples/lazy-hashes-cycles/README.md
+++ b/examples/lazy-hashes-cycles/README.md
@@ -1,0 +1,3 @@
+# Sourcemap and code splitting
+
+Test case for sourcemap and code splitting

--- a/examples/lazy-hashes-cycles/index.js
+++ b/examples/lazy-hashes-cycles/index.js
@@ -1,0 +1,3 @@
+import("./1.js");
+import("./2.js")
+console.log("ok");

--- a/examples/lazy-hashes-cycles/index.js
+++ b/examples/lazy-hashes-cycles/index.js
@@ -1,3 +1,3 @@
 import("./1.js");
-import("./2.js")
+import("./2.js");
 console.log("ok");

--- a/examples/lazy-hashes-cycles/leaf.js
+++ b/examples/lazy-hashes-cycles/leaf.js
@@ -1,0 +1,3 @@
+export default {
+    chunk: 'leaf'
+};

--- a/examples/lazy-hashes-cycles/leaf.js
+++ b/examples/lazy-hashes-cycles/leaf.js
@@ -1,3 +1,3 @@
 export default {
-    chunk: 'leaf'
+  chunk: "leaf",
 };

--- a/examples/lazy-hashes-cycles/package.json
+++ b/examples/lazy-hashes-cycles/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "lazy-hashes-cycles",
+  "description": "Test case for lazy hashes where there is a chunk dependency cycle",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "expect": "^26.6.2",
+    "html-webpack-plugin": ">= 5.0.0-beta.1",
+    "nyc": "*",
+    "webpack": "^5.44.0",
+    "webpack-cli": "4",
+    "webpack-subresource-integrity": "*",
+    "wsi-test-helper": "*"
+  }
+}

--- a/examples/lazy-hashes-cycles/webpack.config.js
+++ b/examples/lazy-hashes-cycles/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   plugins: [
     new SubresourceIntegrityPlugin({
       enabled: true,
-      lazyHashes: true,
+      hashLoading: "lazy",
     }),
     new HtmlWebpackPlugin(),
     {

--- a/examples/lazy-hashes-cycles/webpack.config.js
+++ b/examples/lazy-hashes-cycles/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   plugins: [
     new SubresourceIntegrityPlugin({
       enabled: true,
-      lazyHashes: true
+      lazyHashes: true,
     }),
     new HtmlWebpackPlugin(),
     {
@@ -30,26 +30,39 @@ module.exports = {
           }
           function getSriHashes(chunkName, isEntry) {
             const fileContent = readFileSync(
-              join(__dirname, 'dist', `${chunkName}.js`),
+              join(__dirname, "dist", `${chunkName}.js`),
               "utf-8"
             );
-            const sriRegex = new RegExp(`${isEntry ? 'self.sriHashes=' : 'Object.assign\\(self.sriHashes,'}(?<sriHashJson>\{.*?\})`)
+            const sriRegex = new RegExp(
+              `${
+                isEntry ? "self.sriHashes=" : "Object.assign\\(self.sriHashes,"
+              }(?<sriHashJson>\{.*?\})`
+            );
             const sriHashJson = sriRegex.exec(fileContent)?.groups?.sriHashJson;
             if (!sriHashJson) {
               return null;
             }
             try {
               // The hashes are not *strict* JSON, since they can have numerical keys
-              return JSON.parse(sriHashJson.replace(/\d+(?=:)/g, num => `"${num}"`));
+              return JSON.parse(
+                sriHashJson.replace(/\d+(?=:)/g, (num) => `"${num}"`)
+              );
             } catch (err) {
-              throw new Error(`Could not parse SRI hashes \n\t${sriHashJson}\n in asset: ${err}`)
+              throw new Error(
+                `Could not parse SRI hashes \n\t${sriHashJson}\n in asset: ${err}`
+              );
             }
-          };
+          }
 
-          const indexHashes = getSriHashes('index', true);
+          const indexHashes = getSriHashes("index", true);
           expect(Object.keys(indexHashes).length).toEqual(3);
 
-          expect(stats.toJson().assets.filter(({name}) => /\.js$/.test(name)).every(({integrity}) => !!integrity)).toEqual(true)
+          expect(
+            stats
+              .toJson()
+              .assets.filter(({ name }) => /\.js$/.test(name))
+              .every(({ integrity }) => !!integrity)
+          ).toEqual(true);
         });
       },
     },

--- a/examples/lazy-hashes-cycles/webpack.config.js
+++ b/examples/lazy-hashes-cycles/webpack.config.js
@@ -38,7 +38,8 @@ module.exports = {
                 isEntry ? "self.sriHashes=" : "Object.assign\\(self.sriHashes,"
               }(?<sriHashJson>\{.*?\})`
             );
-            const sriHashJson = sriRegex.exec(fileContent)?.groups?.sriHashJson;
+            const regexMatch = sriRegex.exec(fileContent);
+            const sriHashJson = regexMatch ? regexMatch.groups.sriHashJson : null;
             if (!sriHashJson) {
               return null;
             }

--- a/examples/lazy-hashes-cycles/webpack.config.js
+++ b/examples/lazy-hashes-cycles/webpack.config.js
@@ -1,0 +1,57 @@
+const { SubresourceIntegrityPlugin } = require("webpack-subresource-integrity");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { readFileSync } = require("fs");
+const { join } = require("path");
+const expect = require("expect");
+
+module.exports = {
+  entry: {
+    index: "./index.js",
+  },
+  output: {
+    crossOriginLoading: "anonymous",
+  },
+  plugins: [
+    new SubresourceIntegrityPlugin({
+      enabled: true,
+      lazyHashes: true
+    }),
+    new HtmlWebpackPlugin(),
+    {
+      apply: (compiler) => {
+        compiler.hooks.done.tap("wsi-test", (stats) => {
+          if (stats && stats.hasErrors()) {
+            throw new Error(
+              stats
+                .toJson()
+                .errors.map((error) => error.message)
+                .join(", ")
+            );
+          }
+          function getSriHashes(chunkName, isEntry) {
+            const fileContent = readFileSync(
+              join(__dirname, 'dist', `${chunkName}.js`),
+              "utf-8"
+            );
+            const sriRegex = new RegExp(`${isEntry ? 'self.sriHashes=' : 'Object.assign\\(self.sriHashes,'}(?<sriHashJson>\{.*?\})`)
+            const sriHashJson = sriRegex.exec(fileContent)?.groups?.sriHashJson;
+            if (!sriHashJson) {
+              return null;
+            }
+            try {
+              // The hashes are not *strict* JSON, since they can have numerical keys
+              return JSON.parse(sriHashJson.replace(/\d+(?=:)/g, num => `"${num}"`));
+            } catch (err) {
+              throw new Error(`Could not parse SRI hashes \n\t${sriHashJson}\n in asset: ${err}`)
+            }
+          };
+
+          const indexHashes = getSriHashes('index', true);
+          expect(Object.keys(indexHashes).length).toEqual(3);
+
+          expect(stats.toJson().assets.filter(({name}) => /\.js$/.test(name)).every(({integrity}) => !!integrity)).toEqual(true)
+        });
+      },
+    },
+  ],
+};

--- a/examples/lazy-hashes-cycles/webpack.config.js
+++ b/examples/lazy-hashes-cycles/webpack.config.js
@@ -35,11 +35,15 @@ module.exports = {
             );
             const sriRegex = new RegExp(
               `${
-                isEntry ? "self.sriHashes=" : "Object.assign\\(self.sriHashes,"
+                isEntry
+                  ? "(\\w+|__webpack_require__)\\.sriHashes="
+                  : "Object.assign\\((\\w+|__webpack_require__)\\.sriHashes,"
               }(?<sriHashJson>\{.*?\})`
             );
             const regexMatch = sriRegex.exec(fileContent);
-            const sriHashJson = regexMatch ? regexMatch.groups.sriHashJson : null;
+            const sriHashJson = regexMatch
+              ? regexMatch.groups.sriHashJson
+              : null;
             if (!sriHashJson) {
               return null;
             }

--- a/examples/lazy-hashes-multiple-parents/1.js
+++ b/examples/lazy-hashes-multiple-parents/1.js
@@ -1,0 +1,4 @@
+import("./leaf.js");
+export default {
+  chunk: 1,
+};

--- a/examples/lazy-hashes-multiple-parents/2.js
+++ b/examples/lazy-hashes-multiple-parents/2.js
@@ -1,0 +1,4 @@
+import("./leaf.js");
+export default {
+  chunk: 2,
+};

--- a/examples/lazy-hashes-multiple-parents/README.md
+++ b/examples/lazy-hashes-multiple-parents/README.md
@@ -1,0 +1,3 @@
+# Sourcemap and code splitting
+
+Test case for sourcemap and code splitting

--- a/examples/lazy-hashes-multiple-parents/index.js
+++ b/examples/lazy-hashes-multiple-parents/index.js
@@ -1,0 +1,3 @@
+import("./1.js");
+import("./2.js");
+console.log("ok");

--- a/examples/lazy-hashes-multiple-parents/leaf.js
+++ b/examples/lazy-hashes-multiple-parents/leaf.js
@@ -1,0 +1,3 @@
+export default {
+    chunk: 'leaf'
+};

--- a/examples/lazy-hashes-multiple-parents/leaf.js
+++ b/examples/lazy-hashes-multiple-parents/leaf.js
@@ -1,3 +1,3 @@
 export default {
-    chunk: 'leaf'
+  chunk: "leaf",
 };

--- a/examples/lazy-hashes-multiple-parents/package.json
+++ b/examples/lazy-hashes-multiple-parents/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "lazy-hashes-multiple-parents",
+  "description": "Test case for lazy hashes where a chunk has multiple parents",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "expect": "^26.6.2",
+    "html-webpack-plugin": ">= 5.0.0-beta.1",
+    "nyc": "*",
+    "webpack": "^5.44.0",
+    "webpack-cli": "4",
+    "webpack-subresource-integrity": "*",
+    "wsi-test-helper": "*"
+  }
+}

--- a/examples/lazy-hashes-multiple-parents/webpack.config.js
+++ b/examples/lazy-hashes-multiple-parents/webpack.config.js
@@ -47,13 +47,15 @@ module.exports = {
           };
 
           const indexHashes = getSriHashes('index', true);
-          expect(Object.keys(indexHashes).length).toEqual(1);
+          expect(Object.keys(indexHashes).length).toEqual(2);
 
-          const _1jsHashes = getSriHashes(Object.keys(indexHashes)[0], false);
-          expect(Object.keys(_1jsHashes).length).toEqual(1);
+          const chunkHashes = Object.fromEntries(Object.keys(indexHashes).map(chunkId => 
+            [chunkId, getSriHashes(chunkId, false)]
+          ));
 
-          const _2jsHashes = getSriHashes(Object.keys(_1jsHashes)[0], false);
-          expect(_2jsHashes).toEqual(null);
+          for (const [, intermediateChunkHash] of Object.entries(chunkHashes)) {
+            expect(Object.keys(intermediateChunkHash).length).toEqual(1);
+          }
 
           expect(stats.toJson().assets.filter(({name}) => /\.js$/.test(name)).every(({integrity}) => !!integrity)).toEqual(true)
         });

--- a/examples/lazy-hashes-multiple-parents/webpack.config.js
+++ b/examples/lazy-hashes-multiple-parents/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   plugins: [
     new SubresourceIntegrityPlugin({
       enabled: true,
-      lazyHashes: true,
+      hashLoading: "lazy",
     }),
     new HtmlWebpackPlugin(),
     {

--- a/examples/lazy-hashes-multiple-parents/webpack.config.js
+++ b/examples/lazy-hashes-multiple-parents/webpack.config.js
@@ -38,7 +38,8 @@ module.exports = {
                 isEntry ? "self.sriHashes=" : "Object.assign\\(self.sriHashes,"
               }(?<sriHashJson>\{.*?\})`
             );
-            const sriHashJson = sriRegex.exec(fileContent)?.groups?.sriHashJson;
+            const regexMatch = sriRegex.exec(fileContent);
+            const sriHashJson = regexMatch ? regexMatch.groups.sriHashJson : null;
             if (!sriHashJson) {
               return null;
             }

--- a/examples/lazy-hashes-multiple-parents/webpack.config.js
+++ b/examples/lazy-hashes-multiple-parents/webpack.config.js
@@ -35,11 +35,15 @@ module.exports = {
             );
             const sriRegex = new RegExp(
               `${
-                isEntry ? "self.sriHashes=" : "Object.assign\\(self.sriHashes,"
+                isEntry
+                  ? "(\\w+|__webpack_require__)\\.sriHashes="
+                  : "Object.assign\\((\\w+|__webpack_require__)\\.sriHashes,"
               }(?<sriHashJson>\{.*?\})`
             );
             const regexMatch = sriRegex.exec(fileContent);
-            const sriHashJson = regexMatch ? regexMatch.groups.sriHashJson : null;
+            const sriHashJson = regexMatch
+              ? regexMatch.groups.sriHashJson
+              : null;
             if (!sriHashJson) {
               return null;
             }

--- a/examples/lazy-hashes-multiple-parents/webpack.config.js
+++ b/examples/lazy-hashes-multiple-parents/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   plugins: [
     new SubresourceIntegrityPlugin({
       enabled: true,
-      lazyHashes: true
+      lazyHashes: true,
     }),
     new HtmlWebpackPlugin(),
     {
@@ -30,34 +30,50 @@ module.exports = {
           }
           function getSriHashes(chunkName, isEntry) {
             const fileContent = readFileSync(
-              join(__dirname, 'dist', `${chunkName}.js`),
+              join(__dirname, "dist", `${chunkName}.js`),
               "utf-8"
             );
-            const sriRegex = new RegExp(`${isEntry ? 'self.sriHashes=' : 'Object.assign\\(self.sriHashes,'}(?<sriHashJson>\{.*?\})`)
+            const sriRegex = new RegExp(
+              `${
+                isEntry ? "self.sriHashes=" : "Object.assign\\(self.sriHashes,"
+              }(?<sriHashJson>\{.*?\})`
+            );
             const sriHashJson = sriRegex.exec(fileContent)?.groups?.sriHashJson;
             if (!sriHashJson) {
               return null;
             }
             try {
               // The hashes are not *strict* JSON, since they can have numerical keys
-              return JSON.parse(sriHashJson.replace(/\d+(?=:)/g, num => `"${num}"`));
+              return JSON.parse(
+                sriHashJson.replace(/\d+(?=:)/g, (num) => `"${num}"`)
+              );
             } catch (err) {
-              throw new Error(`Could not parse SRI hashes \n\t${sriHashJson}\n in asset: ${err}`)
+              throw new Error(
+                `Could not parse SRI hashes \n\t${sriHashJson}\n in asset: ${err}`
+              );
             }
-          };
+          }
 
-          const indexHashes = getSriHashes('index', true);
+          const indexHashes = getSriHashes("index", true);
           expect(Object.keys(indexHashes).length).toEqual(2);
 
-          const chunkHashes = Object.fromEntries(Object.keys(indexHashes).map(chunkId => 
-            [chunkId, getSriHashes(chunkId, false)]
-          ));
+          const chunkHashes = Object.fromEntries(
+            Object.keys(indexHashes).map((chunkId) => [
+              chunkId,
+              getSriHashes(chunkId, false),
+            ])
+          );
 
           for (const [, intermediateChunkHash] of Object.entries(chunkHashes)) {
             expect(Object.keys(intermediateChunkHash).length).toEqual(1);
           }
 
-          expect(stats.toJson().assets.filter(({name}) => /\.js$/.test(name)).every(({integrity}) => !!integrity)).toEqual(true)
+          expect(
+            stats
+              .toJson()
+              .assets.filter(({ name }) => /\.js$/.test(name))
+              .every(({ integrity }) => !!integrity)
+          ).toEqual(true);
         });
       },
     },

--- a/examples/lazy-hashes-simple/1.js
+++ b/examples/lazy-hashes-simple/1.js
@@ -1,0 +1,4 @@
+import("./2.js");
+export default {
+  chunk: 1,
+};

--- a/examples/lazy-hashes-simple/2.js
+++ b/examples/lazy-hashes-simple/2.js
@@ -1,0 +1,3 @@
+export default {
+  chunk: 2,
+};

--- a/examples/lazy-hashes-simple/README.md
+++ b/examples/lazy-hashes-simple/README.md
@@ -1,3 +1,3 @@
 # Sourcemap and code splitting
 
-Test case for sourcemap and code splitting
+Simple test case for lazy hashes

--- a/examples/lazy-hashes-simple/README.md
+++ b/examples/lazy-hashes-simple/README.md
@@ -1,0 +1,3 @@
+# Sourcemap and code splitting
+
+Test case for sourcemap and code splitting

--- a/examples/lazy-hashes-simple/index.js
+++ b/examples/lazy-hashes-simple/index.js
@@ -1,0 +1,2 @@
+import("./1.js");
+console.log("ok");

--- a/examples/lazy-hashes-simple/package.json
+++ b/examples/lazy-hashes-simple/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "lazy-hashes-simple",
+  "description": "Simple test case for lazy hashes",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "expect": "^26.6.2",
+    "html-webpack-plugin": ">= 5.0.0-beta.1",
+    "nyc": "*",
+    "webpack": "^5.44.0",
+    "webpack-cli": "4",
+    "webpack-subresource-integrity": "*",
+    "wsi-test-helper": "*"
+  }
+}

--- a/examples/lazy-hashes-simple/webpack.config.js
+++ b/examples/lazy-hashes-simple/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
   plugins: [
     new SubresourceIntegrityPlugin({
       enabled: true,
-      lazyHashes: true,
+      hashLoading: "lazy",
     }),
     new HtmlWebpackPlugin(),
     {

--- a/examples/lazy-hashes-simple/webpack.config.js
+++ b/examples/lazy-hashes-simple/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
   output: {
     crossOriginLoading: "anonymous",
   },
+  // optimization: {minimize: false},
   plugins: [
     new SubresourceIntegrityPlugin({
       enabled: true,
@@ -35,11 +36,15 @@ module.exports = {
             );
             const sriRegex = new RegExp(
               `${
-                isEntry ? "self.sriHashes=" : "Object.assign\\(self.sriHashes,"
+                isEntry
+                  ? "(\\w+|__webpack_require__)\\.sriHashes="
+                  : "Object.assign\\((\\w+|__webpack_require__)\\.sriHashes,"
               }(?<sriHashJson>\{.*?\})`
             );
             const regexMatch = sriRegex.exec(fileContent);
-            const sriHashJson = regexMatch ? regexMatch.groups.sriHashJson : null;
+            const sriHashJson = regexMatch
+              ? regexMatch.groups.sriHashJson
+              : null;
             if (!sriHashJson) {
               return null;
             }

--- a/examples/lazy-hashes-simple/webpack.config.js
+++ b/examples/lazy-hashes-simple/webpack.config.js
@@ -1,0 +1,61 @@
+const { SubresourceIntegrityPlugin } = require("webpack-subresource-integrity");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { readFileSync } = require("fs");
+const { join } = require("path");
+const expect = require("expect");
+
+module.exports = {
+  entry: {
+    index: "./index.js",
+  },
+  output: {
+    crossOriginLoading: "anonymous",
+  },
+  plugins: [
+    new SubresourceIntegrityPlugin({
+      enabled: true,
+      lazyHashes: true
+    }),
+    new HtmlWebpackPlugin(),
+    {
+      apply: (compiler) => {
+        compiler.hooks.done.tap("wsi-test", (stats) => {
+          if (stats && stats.hasErrors()) {
+            throw new Error(
+              stats
+                .toJson()
+                .errors.map((error) => error.message)
+                .join(", ")
+            );
+          }
+          function getSriHashes(chunkName, isEntry) {
+            const fileContent = readFileSync(
+              join(__dirname, 'dist', `${chunkName}.js`),
+              "utf-8"
+            );
+            const sriRegex = new RegExp(`${isEntry ? 'self.sriHashes=' : 'Object.assign\\(self.sriHashes,'}(?<sriHashJson>\{.*?\})`)
+            const sriHashJson = sriRegex.exec(fileContent)?.groups?.sriHashJson;
+            if (!sriHashJson) {
+              return null;
+            }
+            try {
+              // The hashes are not *strict* JSON, since they can have numerical keys
+              return JSON.parse(sriHashJson.replace(/\d+(?=:)/g, num => `"${num}"`));
+            } catch (err) {
+              throw new Error(`Could not parse SRI hashes \n\t${sriHashJson}\n in asset: ${err}`)
+            }
+          };
+
+          const indexHashes = getSriHashes('index', true);
+          expect(Object.keys(indexHashes).length).toEqual(1);
+
+          const _1jsHashes = getSriHashes(Object.keys(indexHashes)[0], false);
+          expect(Object.keys(_1jsHashes).length).toEqual(1);
+
+          const _2jsHashes = getSriHashes(Object.keys(_1jsHashes)[0], false);
+          expect(_2jsHashes).toEqual(null);
+        });
+      },
+    },
+  ],
+};

--- a/examples/lazy-hashes-simple/webpack.config.js
+++ b/examples/lazy-hashes-simple/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   plugins: [
     new SubresourceIntegrityPlugin({
       enabled: true,
-      lazyHashes: true
+      lazyHashes: true,
     }),
     new HtmlWebpackPlugin(),
     {
@@ -30,23 +30,31 @@ module.exports = {
           }
           function getSriHashes(chunkName, isEntry) {
             const fileContent = readFileSync(
-              join(__dirname, 'dist', `${chunkName}.js`),
+              join(__dirname, "dist", `${chunkName}.js`),
               "utf-8"
             );
-            const sriRegex = new RegExp(`${isEntry ? 'self.sriHashes=' : 'Object.assign\\(self.sriHashes,'}(?<sriHashJson>\{.*?\})`)
+            const sriRegex = new RegExp(
+              `${
+                isEntry ? "self.sriHashes=" : "Object.assign\\(self.sriHashes,"
+              }(?<sriHashJson>\{.*?\})`
+            );
             const sriHashJson = sriRegex.exec(fileContent)?.groups?.sriHashJson;
             if (!sriHashJson) {
               return null;
             }
             try {
               // The hashes are not *strict* JSON, since they can have numerical keys
-              return JSON.parse(sriHashJson.replace(/\d+(?=:)/g, num => `"${num}"`));
+              return JSON.parse(
+                sriHashJson.replace(/\d+(?=:)/g, (num) => `"${num}"`)
+              );
             } catch (err) {
-              throw new Error(`Could not parse SRI hashes \n\t${sriHashJson}\n in asset: ${err}`)
+              throw new Error(
+                `Could not parse SRI hashes \n\t${sriHashJson}\n in asset: ${err}`
+              );
             }
-          };
+          }
 
-          const indexHashes = getSriHashes('index', true);
+          const indexHashes = getSriHashes("index", true);
           expect(Object.keys(indexHashes).length).toEqual(1);
 
           const _1jsHashes = getSriHashes(Object.keys(indexHashes)[0], false);
@@ -55,7 +63,12 @@ module.exports = {
           const _2jsHashes = getSriHashes(Object.keys(_1jsHashes)[0], false);
           expect(_2jsHashes).toEqual(null);
 
-          expect(stats.toJson().assets.filter(({name}) => /\.js$/.test(name)).every(({integrity}) => !!integrity)).toEqual(true)
+          expect(
+            stats
+              .toJson()
+              .assets.filter(({ name }) => /\.js$/.test(name))
+              .every(({ integrity }) => !!integrity)
+          ).toEqual(true);
         });
       },
     },

--- a/examples/lazy-hashes-simple/webpack.config.js
+++ b/examples/lazy-hashes-simple/webpack.config.js
@@ -38,7 +38,8 @@ module.exports = {
                 isEntry ? "self.sriHashes=" : "Object.assign\\(self.sriHashes,"
               }(?<sriHashJson>\{.*?\})`
             );
-            const sriHashJson = sriRegex.exec(fileContent)?.groups?.sriHashJson;
+            const regexMatch = sriRegex.exec(fileContent);
+            const sriHashJson = regexMatch ? regexMatch.groups.sriHashJson : null;
             if (!sriHashJson) {
               return null;
             }

--- a/examples/sourcemap-code-splitting/webpack.config.js
+++ b/examples/sourcemap-code-splitting/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = {
           );
           const sriHashesInMap = findAndStripSriHashString(
             "dist/index.js.map",
-            "__webpack_require__.sriHashes = "
+            "self.sriHashes = "
           );
           expect(sriHashesInSource.length).toEqual(sriHashesInMap.length);
         });

--- a/examples/sourcemap-code-splitting/webpack.config.js
+++ b/examples/sourcemap-code-splitting/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = {
           );
           const sriHashesInMap = findAndStripSriHashString(
             "dist/index.js.map",
-            "self.sriHashes = "
+            "__webpack_require__.sriHashes = "
           );
           expect(sriHashesInSource.length).toEqual(sriHashesInMap.length);
         });

--- a/webpack-subresource-integrity/README.md
+++ b/webpack-subresource-integrity/README.md
@@ -172,6 +172,18 @@ One of `"auto"`, `true`, or `false`.
 mode](https://webpack.js.org/configuration/mode/) is `production` or
 `none` and disable it when it is `development`.
 
+#### lazyHashes
+
+Default value: `false`
+
+A boolen used to control where the integrity hashes will be defined.
+
+`false` means that integrity hashes for all assets will be defined in the entry chunk.
+
+`true` means that integrity hashes for any given asset will be defined in its direct parents 
+in the chunk graph. This can lead to duplication of hashes across assets, but can significantly
+reduce the size of your entry chunk(s) if you have a large number of async chunks.
+
 ## Exporting `integrity` values
 
 You might want to export generated integrity hashes, perhaps for use

--- a/webpack-subresource-integrity/README.md
+++ b/webpack-subresource-integrity/README.md
@@ -172,15 +172,15 @@ One of `"auto"`, `true`, or `false`.
 mode](https://webpack.js.org/configuration/mode/) is `production` or
 `none` and disable it when it is `development`.
 
-#### lazyHashes
+#### hashLoading
 
-Default value: `false`
+Default value: `"eager"`
 
-A boolean used to control where the integrity hashes will be defined.
+One of `"eager"` or `"lazy"`
 
-`false` means that integrity hashes for all assets will be defined in the entry chunk.
+`"eager""` means that integrity hashes for all assets will be defined in the entry chunk.
 
-`true` means that integrity hashes for any given asset will be defined in its direct parents 
+`"lazy"` means that integrity hashes for any given asset will be defined in its direct parents 
 in the chunk graph. This can lead to duplication of hashes across assets, but can significantly
 reduce the size of your entry chunk(s) if you have a large number of async chunks.
 

--- a/webpack-subresource-integrity/README.md
+++ b/webpack-subresource-integrity/README.md
@@ -176,7 +176,7 @@ mode](https://webpack.js.org/configuration/mode/) is `production` or
 
 Default value: `false`
 
-A boolen used to control where the integrity hashes will be defined.
+A boolean used to control where the integrity hashes will be defined.
 
 `false` means that integrity hashes for all assets will be defined in the entry chunk.
 

--- a/webpack-subresource-integrity/etc/webpack-subresource-integrity.api.md
+++ b/webpack-subresource-integrity/etc/webpack-subresource-integrity.api.md
@@ -20,7 +20,7 @@ export interface SubresourceIntegrityPluginOptions {
     // (undocumented)
     readonly hashFuncNames?: [string, ...string[]];
     // (undocumented)
-    readonly lazyHashes?: boolean;
+    readonly hashLoading?: "eager" | "lazy";
 }
 
 // (No @packageDocumentation comment for this package)

--- a/webpack-subresource-integrity/etc/webpack-subresource-integrity.api.md
+++ b/webpack-subresource-integrity/etc/webpack-subresource-integrity.api.md
@@ -11,7 +11,7 @@ export class SubresourceIntegrityPlugin {
     constructor(options?: SubresourceIntegrityPluginOptions);
     // (undocumented)
     apply(compiler: Compiler): void;
-    }
+}
 
 // @public (undocumented)
 export interface SubresourceIntegrityPluginOptions {
@@ -19,8 +19,9 @@ export interface SubresourceIntegrityPluginOptions {
     readonly enabled?: "auto" | true | false;
     // (undocumented)
     readonly hashFuncNames?: [string, ...string[]];
+    // (undocumented)
+    readonly lazyHashes?: boolean;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/webpack-subresource-integrity/index.ts
+++ b/webpack-subresource-integrity/index.ts
@@ -38,7 +38,7 @@ let getHtmlWebpackPluginHooks: getHtmlWebpackPluginHooksType | null = null;
 export interface SubresourceIntegrityPluginOptions {
   readonly hashFuncNames?: [string, ...string[]];
   readonly enabled?: "auto" | true | false;
-  readonly lazyHashes?: boolean;
+  readonly hashLoading?: "eager" | "lazy";
 }
 
 class AddLazySriRuntimeModule extends RuntimeModule {
@@ -83,7 +83,7 @@ export class SubresourceIntegrityPlugin {
     this.options = {
       hashFuncNames: ["sha384"],
       enabled: "auto",
-      lazyHashes: false,
+      hashLoading: "eager",
       ...options,
     };
   }
@@ -197,9 +197,10 @@ export class SubresourceIntegrityPlugin {
     );
 
     mainTemplate.hooks.localVars.tap(thisPluginName, (source, chunk) => {
-      const allChunks = this.options.lazyHashes
-        ? plugin.getChildChunksToAddToChunkManifest(chunk)
-        : findChunks(chunk);
+      const allChunks =
+        this.options.hashLoading === "lazy"
+          ? plugin.getChildChunksToAddToChunkManifest(chunk)
+          : findChunks(chunk);
       const includedChunks = chunk.getChunkMaps(false).hash;
 
       if (Object.keys(includedChunks).length > 0) {
@@ -223,7 +224,7 @@ export class SubresourceIntegrityPlugin {
       return source;
     });
 
-    if (this.options.lazyHashes) {
+    if (this.options.hashLoading === "lazy") {
       compilation.hooks.additionalChunkRuntimeRequirements.tap(
         thisPluginName,
         (chunk) => {

--- a/webpack-subresource-integrity/index.ts
+++ b/webpack-subresource-integrity/index.ts
@@ -196,7 +196,7 @@ export class SubresourceIntegrityPlugin {
 
     mainTemplate.hooks.localVars.tap(thisPluginName, (source, chunk) => {
       const allChunks = this.options.lazyHashes
-        ? plugin.getDirectChildChunks(chunk)
+        ? plugin.getChildChunksToAddToChunkManifest(chunk)
         : findChunks(chunk);
       const includedChunks = chunk.getChunkMaps(false).hash;
 
@@ -225,7 +225,7 @@ export class SubresourceIntegrityPlugin {
       compilation.hooks.additionalChunkRuntimeRequirements.tap(
         thisPluginName,
         (chunk) => {
-          const childChunks = plugin.getDirectChildChunks(chunk);
+          const childChunks = plugin.getChildChunksToAddToChunkManifest(chunk);
           if (childChunks.size > 0 && !chunk.hasRuntime()) {
             compilation.addRuntimeModule(
               chunk,

--- a/webpack-subresource-integrity/index.ts
+++ b/webpack-subresource-integrity/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { createHash } from "crypto";
-import type { Chunk, Compiler, Compilation } from "webpack";
+import type { Compiler, Compilation } from "webpack";
 import { javascript, sources } from "webpack";
 import {
   SubresourceIntegrityPluginResolvedOptions,
@@ -212,7 +212,6 @@ export class SubresourceIntegrityPlugin {
         if (childChunks.size === 0 || chunk.hasRuntime()) {
           return originalSource;
         } else {
-          debugger;
           const newSource = new sources.ConcatSource();
 
           newSource.add(

--- a/webpack-subresource-integrity/index.ts
+++ b/webpack-subresource-integrity/index.ts
@@ -181,7 +181,7 @@ export class SubresourceIntegrityPlugin {
         ? plugin.getDirectChildChunks(chunk)
         : findChunks(chunk);
       const includedChunks = chunk.getChunkMaps(false).hash;
-      
+
       if (Object.keys(includedChunks).length > 0) {
         return compilation.compiler.webpack.Template.asString([
           source,

--- a/webpack-subresource-integrity/index.ts
+++ b/webpack-subresource-integrity/index.ts
@@ -44,8 +44,8 @@ export interface SubresourceIntegrityPluginOptions {
 class AddLazySriRuntimeModule extends RuntimeModule {
   private sriHashes: unknown;
 
-  constructor(sriHashes: unknown) {
-    super("webpack-subresource-integrity add SRI hashes lazily");
+  constructor(sriHashes: unknown, chunkName: string | number) {
+    super(`webpack-subresource-integrity lazy hashes for direct children of chunk ${chunkName}`);
     this.sriHashes = sriHashes;
   }
 
@@ -233,7 +233,8 @@ export class SubresourceIntegrityPlugin {
                 generateSriHashPlaceholders(
                   childChunks,
                   this.options.hashFuncNames
-                )
+                ),
+                chunk.name ?? chunk.id
               )
             );
           }

--- a/webpack-subresource-integrity/index.ts
+++ b/webpack-subresource-integrity/index.ts
@@ -45,7 +45,9 @@ class AddLazySriRuntimeModule extends RuntimeModule {
   private sriHashes: unknown;
 
   constructor(sriHashes: unknown, chunkName: string | number) {
-    super(`webpack-subresource-integrity lazy hashes for direct children of chunk ${chunkName}`);
+    super(
+      `webpack-subresource-integrity lazy hashes for direct children of chunk ${chunkName}`
+    );
     this.sriHashes = sriHashes;
   }
 

--- a/webpack-subresource-integrity/package.json
+++ b/webpack-subresource-integrity/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.18.1",
-    "@tsconfig/node10": "^1.0.8",
+    "@tsconfig/node12": "^1.0.9",
     "@types/cross-spawn": "^6.0.2",
     "@types/jest": "^26.0.24",
     "@types/json-schema": "^7.0.8",

--- a/webpack-subresource-integrity/plugin.ts
+++ b/webpack-subresource-integrity/plugin.ts
@@ -297,7 +297,7 @@ more information."
    * @internal
    */
   processAssets = (assets: Record<string, sources.Source>): void => {
-    if (this.options.lazyHashes) {
+    if (this.options.hashLoading === "lazy") {
       for (const scc of this.sortedSccChunks) {
         for (const chunk of scc.nodes) {
           this.processChunkAssets(chunk, assets);
@@ -377,7 +377,7 @@ more information."
    * @internal
    */
   beforeRuntimeRequirements = (): void => {
-    if (this.options.lazyHashes) {
+    if (this.options.hashLoading === "lazy") {
       const [sortedSccChunks, chunkManifest] = getChunkToManifestMap(
         this.compilation.chunks
       );

--- a/webpack-subresource-integrity/plugin.ts
+++ b/webpack-subresource-integrity/plugin.ts
@@ -125,7 +125,9 @@ export class Plugin {
     this.compilation = compilation;
     this.options = options;
     this.reporter = reporter;
-    this.sriHashVariableReference = `${this.compilation.outputOptions.globalObject || 'self'}.sriHashes`
+    this.sriHashVariableReference = `${
+      this.compilation.outputOptions.globalObject || "self"
+    }.sriHashes`;
   }
 
   /**

--- a/webpack-subresource-integrity/plugin.ts
+++ b/webpack-subresource-integrity/plugin.ts
@@ -410,7 +410,6 @@ more information."
   getDirectChildChunks(chunk: Chunk): Set<Chunk> {
     const childChunks = new Set<Chunk>();
     const chunkSCC = this.chunkToSccMap.get(chunk);
-    debugger;
 
     for (const chunkGroup of chunk.groupsIterable) {
       for (const childGroup of chunkGroup.childrenIterable) {
@@ -422,7 +421,7 @@ more information."
             continue;
           }
           for (const childChunkSccNode of childChunkSCC?.nodes ?? []) {
-            childChunks.add(childChunkSccNode)
+            childChunks.add(childChunkSccNode);
           }
         }
       }

--- a/webpack-subresource-integrity/plugin.ts
+++ b/webpack-subresource-integrity/plugin.ts
@@ -12,6 +12,8 @@ import * as assert from "typed-assert";
 import {
   HtmlTagObject,
   SubresourceIntegrityPluginResolvedOptions,
+  Graph,
+  StronglyConnectedComponent,
 } from "./types";
 import { Reporter } from "./reporter";
 import {
@@ -22,8 +24,6 @@ import {
   getTagSrc,
   notNil,
   buildTopologicallySortedChunkGraph,
-  Graph,
-  StronglyConnectedComponent,
 } from "./util";
 
 type AssetType = "js" | "css";
@@ -396,7 +396,7 @@ more information."
   /**
    * @internal
    */
-  beforeRuntimeRequirements = () => {
+  beforeRuntimeRequirements = (): void => {
     if (this.options.lazyHashes) {
       const [sortedSccChunks, sccChunkGraph, chunkToSccMap] =
         buildTopologicallySortedChunkGraph(this.compilation.chunks);

--- a/webpack-subresource-integrity/plugin.ts
+++ b/webpack-subresource-integrity/plugin.ts
@@ -408,16 +408,23 @@ more information."
   };
 
   getDirectChildChunks(chunk: Chunk): Set<Chunk> {
-    const chunkScc = this.chunkToSccMap.get(chunk);
     const childChunks = new Set<Chunk>();
-    if (!chunkScc) {
-      // This is a bug if this happens
-      return childChunks;
-    }
+    const chunkSCC = this.chunkToSccMap.get(chunk);
+    debugger;
 
-    for (const childScc of this.sccChunkGraph.edges.get(chunkScc) ?? []) {
-      for (const childChunk of childScc.nodes) {
-        childChunks.add(childChunk);
+    for (const chunkGroup of chunk.groupsIterable) {
+      for (const childGroup of chunkGroup.childrenIterable) {
+        for (const childChunk of childGroup.chunks) {
+          const childChunkSCC = this.chunkToSccMap.get(childChunk);
+          if (childChunkSCC === chunkSCC) {
+            // Don't include your own SCC.
+            // Your parent will have the hashes for your SCC siblings
+            continue;
+          }
+          for (const childChunkSccNode of childChunkSCC?.nodes ?? []) {
+            childChunks.add(childChunkSccNode)
+          }
+        }
       }
     }
 

--- a/webpack-subresource-integrity/plugin.ts
+++ b/webpack-subresource-integrity/plugin.ts
@@ -24,6 +24,7 @@ import {
   getTagSrc,
   notNil,
   buildTopologicallySortedChunkGraph,
+  sriHashVariableReference,
 } from "./util";
 
 type AssetType = "js" | "css";
@@ -112,11 +113,6 @@ export class Plugin {
    */
   private hashByChunkId = new Map<string | number, string>();
 
-  /**
-   * @internal
-   */
-  public readonly sriHashVariableReference: string;
-
   public constructor(
     compilation: Compilation,
     options: SubresourceIntegrityPluginResolvedOptions,
@@ -125,9 +121,6 @@ export class Plugin {
     this.compilation = compilation;
     this.options = options;
     this.reporter = reporter;
-    this.sriHashVariableReference = `${
-      this.compilation.outputOptions.globalObject || "self"
-    }.sriHashes`;
   }
 
   /**
@@ -305,7 +298,7 @@ more information."
 
     return this.compilation.compiler.webpack.Template.asString([
       source,
-      elName + `.integrity = ${this.sriHashVariableReference}[chunkId];`,
+      elName + `.integrity = ${sriHashVariableReference}[chunkId];`,
       elName +
         ".crossOrigin = " +
         JSON.stringify(this.compilation.outputOptions.crossOriginLoading) +

--- a/webpack-subresource-integrity/plugin.ts
+++ b/webpack-subresource-integrity/plugin.ts
@@ -400,11 +400,16 @@ more information."
     this.hashByChunkId.clear();
   };
 
-  getDirectChildChunks(chunk: Chunk): Set<Chunk> {
+  getChildChunksToAddToChunkManifest(chunk: Chunk): Set<Chunk> {
     const childChunks = new Set<Chunk>();
     const chunkSCC = this.chunkToSccMap.get(chunk);
 
     for (const chunkGroup of chunk.groupsIterable) {
+      if (chunkGroup.chunks[chunkGroup.chunks.length - 1] !== chunk) {
+        // Only add sri hashes for one chunk per chunk group,
+        // where the last chunk in the group is the primary chunk
+        continue;
+      }
       for (const childGroup of chunkGroup.childrenIterable) {
         for (const childChunk of childGroup.chunks) {
           const childChunkSCC = this.chunkToSccMap.get(childChunk);

--- a/webpack-subresource-integrity/tsconfig.json
+++ b/webpack-subresource-integrity/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node10/tsconfig.json",
+  "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,

--- a/webpack-subresource-integrity/types.ts
+++ b/webpack-subresource-integrity/types.ts
@@ -12,4 +12,5 @@ export type getHtmlWebpackPluginHooksType = (
 export interface SubresourceIntegrityPluginResolvedOptions {
   readonly hashFuncNames: [string, ...string[]];
   readonly enabled: "auto" | true | false;
+  readonly lazyHashes: boolean;
 }

--- a/webpack-subresource-integrity/types.ts
+++ b/webpack-subresource-integrity/types.ts
@@ -12,7 +12,7 @@ export type getHtmlWebpackPluginHooksType = (
 export interface SubresourceIntegrityPluginResolvedOptions {
   readonly hashFuncNames: [string, ...string[]];
   readonly enabled: "auto" | true | false;
-  readonly lazyHashes: boolean;
+  readonly hashLoading: "eager" | "lazy";
 }
 
 export interface Graph<T> {

--- a/webpack-subresource-integrity/types.ts
+++ b/webpack-subresource-integrity/types.ts
@@ -14,3 +14,12 @@ export interface SubresourceIntegrityPluginResolvedOptions {
   readonly enabled: "auto" | true | false;
   readonly lazyHashes: boolean;
 }
+
+export interface Graph<T> {
+  vertices: Set<T>;
+  edges: Map<T, Set<T>>;
+}
+
+export interface StronglyConnectedComponent<T> {
+  nodes: Set<T>;
+}

--- a/webpack-subresource-integrity/util.ts
+++ b/webpack-subresource-integrity/util.ts
@@ -88,3 +88,167 @@ export function notNil<TValue>(
 ): value is TValue {
   return value !== null && value !== undefined;
 }
+
+export function generateSriHashPlaceholders(chunks: Iterable<Chunk>, hashFuncNames: [string, ...string[]]) {
+  return Array.from(chunks).reduce((sriHashes, depChunk: Chunk) => {
+    if (depChunk.id) {
+      sriHashes[depChunk.id] = makePlaceholder(
+        hashFuncNames,
+        depChunk.id
+      );
+    }
+    return sriHashes;
+  }, {} as { [key: string]: string })
+}
+
+export interface Graph<T> {
+  vertices: Set<T>;
+  edges: Map<T, Set<T>>;
+}
+
+export function buildTopologicallySortedChunkGraph(chunks: Iterable<Chunk>): 
+  [
+    sortedVertices: StronglyConnectedComponent<Chunk>[], 
+    sccGraph: Graph<StronglyConnectedComponent<Chunk>>,
+    chunkToSccMap: Map<Chunk, StronglyConnectedComponent<Chunk>>
+  ] {
+  const queue = [...chunks];
+  const vertices = new Set<Chunk>();
+  const edges = new Map<Chunk, Set<Chunk>>();
+
+  while (queue.length) {
+    const vertex = queue.pop()!;
+    vertices.add(vertex);
+    edges.set(vertex, new Set<Chunk>());
+    for (const vertexGroup of vertex.groupsIterable) {
+      for (const childGroup of vertexGroup.childrenIterable) {
+        for (const childChunk of childGroup.chunks) {
+          edges.get(vertex)?.add(childChunk);
+          if (!vertices.has(childChunk)) {
+            queue.push(childChunk);
+          }
+        }
+      }
+    }
+  }
+
+  const dag = createDAGfromGraph({vertices, edges});
+
+  const sortedVertices = topologicalSort(dag);
+  const chunkToSccMap = new Map<Chunk, StronglyConnectedComponent<Chunk>>();
+  for (const scc of dag.vertices) {
+    for (const chunk of scc.nodes) {
+      chunkToSccMap.set(chunk, scc)
+    }
+  }
+
+  return [sortedVertices, dag, chunkToSccMap];
+}
+
+export interface StronglyConnectedComponent<T> {
+  nodes: Set<T>;
+}
+
+interface TarjanVertexMetadata {index?: number, lowlink?: number, onstack?: boolean}
+
+/**
+ * Tarjan's strongly connected components algorithm
+ * https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+ */
+function createDAGfromGraph<T>({vertices, edges}: Graph<T>): Graph<StronglyConnectedComponent<T>> {
+  let index = 0;
+  const stack: T[] = [];
+  const vertexMetadata = new Map<T, TarjanVertexMetadata>([...vertices].map(vertex => [vertex, {}]));
+
+  const stronglyConnectedComponents = new Set<StronglyConnectedComponent<T>>();
+
+  for (const vertex of vertices) {
+    if (vertexMetadata.get(vertex)!.index === undefined) {
+      strongConnect(vertex);
+    }
+  }
+
+  function strongConnect(vertex: T) {
+    // Set the depth index for v to the smallest unused index
+    const vertexData = vertexMetadata.get(vertex)!;
+    vertexData.index = index;
+    vertexData.lowlink = index;
+    index++;
+    stack.push(vertex);
+    vertexData.onstack = true;
+
+    for (const child of edges.get(vertex) ?? []) {
+      const childData = vertexMetadata.get(child)!;
+      if (childData.index === undefined) {
+        // Child has not yet been visited; recurse on it
+        strongConnect(child);
+        vertexData.lowlink = Math.min(vertexData.lowlink, childData.lowlink!)
+      } else if (childData.onstack) {
+        // Child is in stack and hence in the current SCC
+        // If child is not on stack, then (vertex, child) is an edge pointing to an SCC already found and must be ignored
+        // Note: The next line may look odd - but is correct.
+        // It says childData.index not childData.lowlink; that is deliberate and from the original paper
+        vertexData.lowlink = Math.min(vertexData.lowlink, childData.index)
+      }
+    }
+    
+    // If vertex is a root node, pop the stack and generate an SCC
+    if (vertexData.index === vertexData.lowlink) {
+      const newStronglyConnectedComponent = {nodes: new Set<T>()};
+      let currentNode: T;
+      do {
+        currentNode = stack.pop()!;
+        vertexMetadata.get(currentNode)!.onstack = false;
+        newStronglyConnectedComponent.nodes.add(currentNode);
+      } while (currentNode !== vertex)
+
+      stronglyConnectedComponents.add(newStronglyConnectedComponent);
+    }
+  }
+
+  // Now that all SCCs have been identified, rebuild the graph
+  const vertexToSCCMap = new Map<T, StronglyConnectedComponent<T>>();
+  const sccEdges = new Map<StronglyConnectedComponent<T>, Set<StronglyConnectedComponent<T>>>();
+
+  for (const scc of stronglyConnectedComponents) {
+    for (const vertex of scc.nodes) {
+      vertexToSCCMap.set(vertex, scc);
+    }
+  }
+
+  for (const scc of stronglyConnectedComponents) {
+    const childSCCNodes = new Set<StronglyConnectedComponent<T>>();
+    for (const vertex of scc.nodes) {
+      for (const childVertex of edges.get(vertex) ?? []) {
+        childSCCNodes.add(vertexToSCCMap.get(childVertex)!)
+      }
+    }
+    sccEdges.set(scc, childSCCNodes);
+  }
+
+  return { vertices: stronglyConnectedComponents, edges: sccEdges};
+}
+
+// This implementation assumes a directed acyclic graph (such as one produce by createDAGfromGraph),
+// and does not attempt to detect cycles
+function topologicalSort<T>({vertices, edges}: Graph<T>): T[] {
+  const sortedItems: T[] = [];
+
+  const seenNodes= new Set<T>();
+
+  function visit(node: T) {
+    if (seenNodes.has(node)) {
+      return;
+    }
+
+    seenNodes.add(node);
+
+    for (const child of edges.get(node) ?? []) {
+      visit(child);
+    }
+
+    sortedItems.push(node);
+  }
+
+  return sortedItems;
+}

--- a/webpack-subresource-integrity/util.ts
+++ b/webpack-subresource-integrity/util.ts
@@ -136,12 +136,9 @@ export function buildTopologicallySortedChunkGraph(
   const dag = createDAGfromGraph({ vertices, edges });
 
   const sortedVertices = topologicalSort(dag);
-  const chunkToSccMap = new Map<Chunk, StronglyConnectedComponent<Chunk>>();
-  for (const scc of dag.vertices) {
-    for (const chunk of scc.nodes) {
-      chunkToSccMap.set(chunk, scc);
-    }
-  }
+  const chunkToSccMap = new Map<Chunk, StronglyConnectedComponent<Chunk>>(
+    [...dag.vertices].flatMap((scc) => [...scc.nodes].map(chunk => [chunk, scc]))
+  );
 
   return [sortedVertices, dag, chunkToSccMap];
 }

--- a/webpack-subresource-integrity/util.ts
+++ b/webpack-subresource-integrity/util.ts
@@ -12,6 +12,8 @@ import type { HtmlTagObject, Graph, StronglyConnectedComponent } from "./types";
 
 type ChunkGroup = ReturnType<Compilation["addChunkInGroup"]>;
 
+export const sriHashVariableReference = "__webpack_require__.sriHashes";
+
 export function getTagSrc(tag: HtmlTagObject): string | undefined {
   if (!["script", "link"].includes(tag.tagName) || !tag.attributes) {
     return undefined;

--- a/webpack-subresource-integrity/util.ts
+++ b/webpack-subresource-integrity/util.ts
@@ -12,7 +12,6 @@ import { HtmlTagObject } from "./types";
 
 type ChunkGroup = ReturnType<Compilation["addChunkInGroup"]>;
 
-
 export function getTagSrc(tag: HtmlTagObject): string | undefined {
   if (!["script", "link"].includes(tag.tagName) || !tag.attributes) {
     return undefined;
@@ -117,7 +116,7 @@ export function buildTopologicallySortedChunkGraph(
   const queue = [...chunks];
   const vertices = new Set<Chunk>();
   const edges = new Map<Chunk, Set<Chunk>>();
-  
+
   while (queue.length) {
     const vertex = queue.pop()!;
     if (vertices.has(vertex)) {
@@ -267,7 +266,7 @@ function topologicalSort<T>({ vertices, edges }: Graph<T>): T[] {
 
     sortedItems.push(node);
   }
-  
+
   for (const vertex of vertices) {
     visit(vertex);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6815,6 +6815,20 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
+"lazy-hashes-cycles@workspace:examples/lazy-hashes-cycles":
+  version: 0.0.0-use.local
+  resolution: "lazy-hashes-cycles@workspace:examples/lazy-hashes-cycles"
+  dependencies:
+    expect: ^26.6.2
+    html-webpack-plugin: ">= 5.0.0-beta.1"
+    nyc: "*"
+    webpack: ^5.44.0
+    webpack-cli: 4
+    webpack-subresource-integrity: "*"
+    wsi-test-helper: "*"
+  languageName: unknown
+  linkType: soft
+
 "lazy-hashes-multiple-parents@workspace:examples/lazy-hashes-multiple-parents":
   version: 0.0.0-use.local
   resolution: "lazy-hashes-multiple-parents@workspace:examples/lazy-hashes-multiple-parents"

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,6 +796,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsconfig/node12@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "@tsconfig/node12@npm:1.0.9"
+  checksum: a01b2400ab3582b86b589c6d31dcd0c0656f333adecde85d6d7d4086adb059808b82692380bb169546d189bf771ae21d02544a75b57bd6da4a5dd95f8567bec9
+  languageName: node
+  linkType: hard
+
 "@types/argparse@npm:1.0.38":
   version: 1.0.38
   resolution: "@types/argparse@npm:1.0.38"
@@ -11179,7 +11186,7 @@ typescript@^3.3.3:
   resolution: "webpack-subresource-integrity@workspace:webpack-subresource-integrity"
   dependencies:
     "@microsoft/api-extractor": ^7.18.1
-    "@tsconfig/node10": ^1.0.8
+    "@tsconfig/node12": ^1.0.9
     "@types/cross-spawn": ^6.0.2
     "@types/jest": ^26.0.24
     "@types/json-schema": ^7.0.8

--- a/yarn.lock
+++ b/yarn.lock
@@ -6815,6 +6815,20 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
+"lazy-hashes-simple@workspace:examples/lazy-hashes-simple":
+  version: 0.0.0-use.local
+  resolution: "lazy-hashes-simple@workspace:examples/lazy-hashes-simple"
+  dependencies:
+    expect: ^26.6.2
+    html-webpack-plugin: ">= 5.0.0-beta.1"
+    nyc: "*"
+    webpack: ^5.44.0
+    webpack-cli: 4
+    webpack-subresource-integrity: "*"
+    wsi-test-helper: "*"
+  languageName: unknown
+  linkType: soft
+
 "lcov-parse@npm:^1.0.0":
   version: 1.0.0
   resolution: "lcov-parse@npm:1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6815,6 +6815,20 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
+"lazy-hashes-multiple-parents@workspace:examples/lazy-hashes-multiple-parents":
+  version: 0.0.0-use.local
+  resolution: "lazy-hashes-multiple-parents@workspace:examples/lazy-hashes-multiple-parents"
+  dependencies:
+    expect: ^26.6.2
+    html-webpack-plugin: ">= 5.0.0-beta.1"
+    nyc: "*"
+    webpack: ^5.44.0
+    webpack-cli: 4
+    webpack-subresource-integrity: "*"
+    wsi-test-helper: "*"
+  languageName: unknown
+  linkType: soft
+
 "lazy-hashes-simple@workspace:examples/lazy-hashes-simple":
   version: 0.0.0-use.local
   resolution: "lazy-hashes-simple@workspace:examples/lazy-hashes-simple"


### PR DESCRIPTION
- [x] Fixes #171 

Adds new option `lazyHashes` (name subject to change), which controls new behavior that creates a directed acyclic graph of the chunk graph by reducing cycles to [strongly-connected components](https://en.wikipedia.org/wiki/Strongly_connected_component). The DAG is then [topologically sorted](https://en.wikipedia.org/wiki/Topological_sorting) such that the integrity hashes are calculated from the leaf nodes up, so the hash of the assets with child integrity hashes are not invalidated.

I did some minor refactoring in the process, but the only behavioral change for the default configuration was moving the hashes from `__webpack_require__.sriHashes` to `${globalObject}.sriHashes`. In testing, I ran into issues where async chunks could not access `__webpack_require__`.

I still need to write tests, but the holidays are approaching, and I will be OOF for the last two weeks of the year. I wanted to make sure I got this out for the maintainers to look at before I disappeared for a while. I have verified that this *does* work in my group's project with a very large chunk graph (>1.5k chunks).
