### PR TITLE
Lazy hashes -- follow up

### DIFF
--- a/examples/lazy-e2e/index.js
+++ b/examples/lazy-e2e/index.js
@@ -1,0 +1,1 @@
+import("./nested1");

--- a/examples/lazy-e2e/nested1.js
+++ b/examples/lazy-e2e/nested1.js
@@ -1,0 +1,1 @@
+import("./nested2");

--- a/examples/lazy-e2e/nested2.js
+++ b/examples/lazy-e2e/nested2.js
@@ -1,0 +1,1 @@
+console.log("ok");

--- a/examples/lazy-e2e/package.json
+++ b/examples/lazy-e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "lazy-e2e",
+  "description": "Basic end-to-end test with lazy-loaded hashes",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "html-webpack-plugin": ">= 5.0.0-beta.1",
+    "nyc": "*",
+    "webpack": "^5.44.0",
+    "webpack-cli": "4",
+    "webpack-subresource-integrity": "*",
+    "wsi-test-helper": "*"
+  }
+}

--- a/examples/lazy-e2e/webpack.config.js
+++ b/examples/lazy-e2e/webpack.config.js
@@ -1,0 +1,21 @@
+const { SubresourceIntegrityPlugin } = require("webpack-subresource-integrity");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { RunInPuppeteerPlugin } = require("wsi-test-helper");
+
+module.exports = {
+  entry: {
+    index: "./index.js",
+  },
+  output: {
+    crossOriginLoading: "anonymous",
+  },
+  plugins: [
+    new SubresourceIntegrityPlugin({
+      hashFuncNames: ["sha256"],
+      enabled: true,
+      lazyHashes: true,
+    }),
+    new HtmlWebpackPlugin(),
+    new RunInPuppeteerPlugin(),
+  ],
+};

--- a/examples/lazy-modified/README.md
+++ b/examples/lazy-modified/README.md
@@ -1,0 +1,4 @@
+# With lazy hashes and a modified dynamically loaded chunk #hwp
+
+Ensure that when a chunk is modified, it fails to load when hashes are
+lazy-loaded.

--- a/examples/lazy-modified/corrupt.js
+++ b/examples/lazy-modified/corrupt.js
@@ -1,0 +1,1 @@
+console.log("this should never load");

--- a/examples/lazy-modified/index.js
+++ b/examples/lazy-modified/index.js
@@ -1,0 +1,1 @@
+import("./nested");

--- a/examples/lazy-modified/nested.js
+++ b/examples/lazy-modified/nested.js
@@ -1,0 +1,7 @@
+import(/* webpackChunkName: "corrupt" */ "./corrupt")
+  .then(function error() {
+    console.log("error");
+  })
+  .catch(function ok() {
+    console.log("ok");
+  });

--- a/examples/lazy-modified/package.json
+++ b/examples/lazy-modified/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "lazy-modified",
+  "description": "Ensure that when a chunk is modified, it fails to load when hashes are lazy-loaded.",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "html-webpack-plugin": ">= 5.0.0-beta.1",
+    "nyc": "*",
+    "webpack": "^5.44.0",
+    "webpack-cli": "4",
+    "webpack-subresource-integrity": "*",
+    "wsi-test-helper": "*"
+  }
+}

--- a/examples/lazy-modified/webpack.config.js
+++ b/examples/lazy-modified/webpack.config.js
@@ -1,0 +1,43 @@
+const { SubresourceIntegrityPlugin } = require("webpack-subresource-integrity");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { RunInPuppeteerPlugin } = require("wsi-test-helper");
+const { writeFileSync } = require("fs");
+
+let gotError = false;
+
+module.exports = {
+  entry: {
+    index: "./index.js",
+  },
+  output: {
+    crossOriginLoading: "anonymous",
+  },
+  plugins: [
+    new SubresourceIntegrityPlugin({
+      hashFuncNames: ["sha256", "sha384"],
+      lazyHashes: true,
+    }),
+    new HtmlWebpackPlugin(),
+    new RunInPuppeteerPlugin({
+      onStart: (stats) => {
+        console.log(stats.compilation.assets);
+        writeFileSync("dist/corrupt.js", 'console.log("corrupted");');
+      },
+      onConsoleError: (msg) => {
+        console.log(msg);
+        if (
+          msg.match(
+            /Failed to find a valid digest in the 'integrity' attribute for resource/
+          )
+        ) {
+          gotError = true;
+        }
+      },
+      onDone: () => {
+        if (!gotError) {
+          throw new Error("No error was raised");
+        }
+      },
+    }),
+  ],
+};

--- a/webpack-subresource-integrity/index.ts
+++ b/webpack-subresource-integrity/index.ts
@@ -261,7 +261,9 @@ export class SubresourceIntegrityPlugin {
           "See https://w3c.github.io/webappsec-subresource-integrity/#cross-origin-data-leakage"
       );
     }
-    return this.validateHashFuncNames(reporter);
+    return (
+      this.validateHashFuncNames(reporter) && this.validateHashLoading(reporter)
+    );
   };
 
   /**
@@ -289,6 +291,25 @@ export class SubresourceIntegrityPlugin {
       this.warnStandardHashFunc(reporter);
       return true;
     }
+  };
+
+  /**
+   * @internal
+   */
+  private validateHashLoading = (reporter: Reporter): boolean => {
+    const supportedHashLoadingOptions = Object.freeze(["eager", "lazy"]);
+    if (supportedHashLoadingOptions.includes(this.options.hashLoading)) {
+      return true;
+    }
+
+    const optionsStr = supportedHashLoadingOptions
+      .map((opt) => `'${opt}'`)
+      .join(", ");
+
+    reporter.error(
+      `options.hashLoading must be one of ${optionsStr}, instead got '${this.options.hashLoading}'`
+    );
+    return false;
   };
 
   /**

--- a/webpack-subresource-integrity/unit.test.ts
+++ b/webpack-subresource-integrity/unit.test.ts
@@ -8,6 +8,7 @@
 import webpack, { Compiler, Compilation, Configuration, Chunk } from "webpack";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import { SubresourceIntegrityPlugin } from "./index.js";
+import type { SubresourceIntegrityPluginOptions } from "./index.js";
 
 jest.unmock("html-webpack-plugin");
 
@@ -159,6 +160,26 @@ test("errors if hash function names contains unsupported digest", async () => {
   expect(compilation.warnings.length).toBe(0);
   expect(compilation.errors[0].message).toMatch(
     /Cannot use hash function 'frobnicate': Digest method not supported/
+  );
+});
+
+test("errors if hashLoading option uses unknown value", async () => {
+  const plugin = new SubresourceIntegrityPlugin({
+    hashLoading:
+      "invalid" as unknown as SubresourceIntegrityPluginOptions["hashLoading"],
+  });
+
+  const compilation = await runCompilation(
+    webpack({
+      ...defaultOptions,
+      plugins: [plugin],
+    })
+  );
+
+  expect(compilation.errors.length).toBe(1);
+  expect(compilation.warnings.length).toBe(0);
+  expect(compilation.errors[0].message).toMatch(
+    /options.hashLoading must be one of 'eager', 'lazy', instead got 'invalid'/
   );
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6815,6 +6815,19 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
+"lazy-e2e@workspace:examples/lazy-e2e":
+  version: 0.0.0-use.local
+  resolution: "lazy-e2e@workspace:examples/lazy-e2e"
+  dependencies:
+    html-webpack-plugin: ">= 5.0.0-beta.1"
+    nyc: "*"
+    webpack: ^5.44.0
+    webpack-cli: 4
+    webpack-subresource-integrity: "*"
+    wsi-test-helper: "*"
+  languageName: unknown
+  linkType: soft
+
 "lazy-hashes-cycles@workspace:examples/lazy-hashes-cycles":
   version: 0.0.0-use.local
   resolution: "lazy-hashes-cycles@workspace:examples/lazy-hashes-cycles"
@@ -6848,6 +6861,19 @@ fsevents@^2.1.2:
   resolution: "lazy-hashes-simple@workspace:examples/lazy-hashes-simple"
   dependencies:
     expect: ^26.6.2
+    html-webpack-plugin: ">= 5.0.0-beta.1"
+    nyc: "*"
+    webpack: ^5.44.0
+    webpack-cli: 4
+    webpack-subresource-integrity: "*"
+    wsi-test-helper: "*"
+  languageName: unknown
+  linkType: soft
+
+"lazy-modified@workspace:examples/lazy-modified":
+  version: 0.0.0-use.local
+  resolution: "lazy-modified@workspace:examples/lazy-modified"
+  dependencies:
     html-webpack-plugin: ">= 5.0.0-beta.1"
     nyc: "*"
     webpack: ^5.44.0


### PR DESCRIPTION
Adds two end-to-end tests, one to ensure a page with lazy hash loading works in Puppeteer, and one to ensure it fails to load when a (deeply nested) chunk is corrupt. Also adds feedback when the `hashLoading` option receives an invalid setting.
