### PR TITLE
Allow skipping chunks

### DIFF
--- a/webpack-subresource-integrity/etc/webpack-subresource-integrity.api.md
+++ b/webpack-subresource-integrity/etc/webpack-subresource-integrity.api.md
@@ -21,6 +21,8 @@ export interface SubresourceIntegrityPluginOptions {
     readonly hashFuncNames?: [string, ...string[]];
     // (undocumented)
     readonly hashLoading?: "eager" | "lazy";
+    // (undocumented)
+    readonly skipChunkNames?: string[];
 }
 
 // (No @packageDocumentation comment for this package)

--- a/webpack-subresource-integrity/index.ts
+++ b/webpack-subresource-integrity/index.ts
@@ -85,6 +85,7 @@ export class SubresourceIntegrityPlugin {
       hashFuncNames: ["sha384"],
       enabled: "auto",
       hashLoading: "eager",
+      skipChunkNames: [],
       ...options,
     };
   }

--- a/webpack-subresource-integrity/index.ts
+++ b/webpack-subresource-integrity/index.ts
@@ -205,6 +205,10 @@ export class SubresourceIntegrityPlugin {
           : findChunks(chunk);
       const includedChunks = chunk.getChunkMaps(false).hash;
 
+      if (this.options.skipChunkNames.includes(chunk.name)) {
+        return source;
+      }
+
       if (Object.keys(includedChunks).length > 0) {
         return compilation.compiler.webpack.Template.asString([
           source,

--- a/webpack-subresource-integrity/index.ts
+++ b/webpack-subresource-integrity/index.ts
@@ -39,6 +39,7 @@ export interface SubresourceIntegrityPluginOptions {
   readonly hashFuncNames?: [string, ...string[]];
   readonly enabled?: "auto" | true | false;
   readonly hashLoading?: "eager" | "lazy";
+  readonly skipChunkNames?: string[]
 }
 
 class AddLazySriRuntimeModule extends RuntimeModule {

--- a/webpack-subresource-integrity/integration.test.ts
+++ b/webpack-subresource-integrity/integration.test.ts
@@ -10,16 +10,18 @@ import {
   StatsAsset,
   WebpackError,
   WebpackOptionsNormalized,
-  container
+  container,
 } from "webpack";
 import { resolve } from "path";
 import tmp from "tmp-promise";
-import { SubresourceIntegrityPlugin, SubresourceIntegrityPluginOptions } from "./index.js";
+import {
+  SubresourceIntegrityPlugin,
+  SubresourceIntegrityPluginOptions,
+} from "./index.js";
 import { runWebpack } from "./test-utils";
 import merge from "lodash/merge";
 
 const { ModuleFederationPlugin } = container;
-
 
 jest.unmock("html-webpack-plugin");
 
@@ -47,20 +49,20 @@ async function runWebpackForModuleFederationProject(
   options: Partial<SubresourceIntegrityPluginOptions> = {}
 ): Promise<Stats> {
   const tmpDir = await tmp.dir({ unsafeCleanup: true });
-  return await runWebpack(
-      {
-        mode: "production",
-        output: { path: tmpDir.path, crossOriginLoading: "anonymous" },
-        entry: resolve(
-          __dirname,
-          "./test-fixtures/module-federation/src/index.js"
-        ),
-        plugins: [new SubresourceIntegrityPlugin(options), new ModuleFederationPlugin({name: 'host', remotes: {
-          "module": "module@localhost:3000/remoteEntry.js"
-        }})],
-
-      }
-  );
+  return await runWebpack({
+    mode: "production",
+    output: { path: tmpDir.path, crossOriginLoading: "anonymous" },
+    entry: resolve(__dirname, "./test-fixtures/module-federation/src/index.js"),
+    plugins: [
+      new SubresourceIntegrityPlugin(options),
+      new ModuleFederationPlugin({
+        name: "host",
+        remotes: {
+          module: "module@localhost:3000/remoteEntry.js",
+        },
+      }),
+    ],
+  });
 }
 
 test("enabled with webpack mode=production", async () => {
@@ -116,19 +118,20 @@ test("doesn't warn with default options", async () => {
 
 test("fail on module federation", async () => {
   try {
-  const stats = await runWebpackForModuleFederationProject();
-  }
-  catch(error) {
-  
-  expect(error.message.includes("Asset main.js contains unresolved integrity placeholders")).toBeTruthy();;
+    const stats = await runWebpackForModuleFederationProject();
+  } catch (error) {
+    expect(
+      error.message.includes(
+        "Asset main.js contains unresolved integrity placeholders"
+      )
+    ).toBeTruthy();
   }
 });
 
 test("can skip chunks", async () => {
-  
-  const stats = await runWebpackForModuleFederationProject({skipChunkNames: ['main']});
- 
-  
+  const stats = await runWebpackForModuleFederationProject({
+    skipChunkNames: ["main"],
+  });
+
   expect(stats.compilation.warnings).toHaveLength(0);
-  
 });

--- a/webpack-subresource-integrity/plugin.ts
+++ b/webpack-subresource-integrity/plugin.ts
@@ -300,12 +300,14 @@ more information."
     if (this.options.hashLoading === "lazy") {
       for (const scc of this.sortedSccChunks) {
         for (const chunk of scc.nodes) {
-          this.processChunkAssets(chunk, assets);
+          if (!this.options.skipChunkNames.includes(chunk.name)) {
+            this.processChunkAssets(chunk, assets);
+          }
         }
       }
     } else {
       Array.from(this.compilation.chunks)
-        .filter((chunk) => chunk.hasRuntime())
+        .filter((chunk) => chunk.hasRuntime() && !this.options.skipChunkNames.includes(chunk.name))
         .forEach((chunk) => {
           this.processChunk(chunk, assets);
         });

--- a/webpack-subresource-integrity/test-fixtures/module-federation/src/index.js
+++ b/webpack-subresource-integrity/test-fixtures/module-federation/src/index.js
@@ -1,0 +1,2 @@
+import("module/remoteEntry.js");
+console.log("ok");

--- a/webpack-subresource-integrity/types.ts
+++ b/webpack-subresource-integrity/types.ts
@@ -13,6 +13,7 @@ export interface SubresourceIntegrityPluginResolvedOptions {
   readonly hashFuncNames: [string, ...string[]];
   readonly enabled: "auto" | true | false;
   readonly hashLoading: "eager" | "lazy";
+  readonly skipChunkNames: string[];
 }
 
 export interface Graph<T> {


### PR DESCRIPTION
Hello,

This attempts to solve #176. We are trying to adapt module federation in our application. Since we are using this plugin, we cannot. 

Since our federated modules are all loaded from our servers, but updated often, we decided it is okay to skip SRI generation for these as suggested [here](https://github.com/webpack/webpack/issues/14310#issuecomment-1046285049).  

I am not very familiar with the inner workings of webpack or this plugin, so please do a very detailed review. I wrote a test for it, but I don't feel exactly comfortable and I might have just broken everything, but I wanted to help to get this off the ground, so hopefully this is useful. 

Thanks a lot,
Christian