### PR TITLE
Fix for issue 181

### DIFF
--- a/webpack-subresource-integrity/src/util.ts
+++ b/webpack-subresource-integrity/src/util.ts
@@ -117,7 +117,7 @@ export function generateSriHashPlaceholders(
   hashFuncNames: [string, ...string[]]
 ): Record<string, string> {
   return Array.from(chunks).reduce((sriHashes, depChunk: Chunk) => {
-    if (depChunk.id) {
+    if (depChunk.id || depChunk.id === 0) {
       sriHashes[depChunk.id] = makePlaceholder(hashFuncNames, depChunk.id);
     }
     return sriHashes;


### PR DESCRIPTION
Webpack build in Angular with `namedChunks` set to `false` emits the zeroth script with an `id` of `0`. This means its integrity hash is not added to `sriHashes` as `depChunks.id` evaluates as falsy. This means the zeroth script generated by webpack has its `integrity` property set to `undefined` triggering the following error:

Error parsing 'integrity' attribute ('undefined'). The hash algorithm must be one of 'sha256', 'sha384', or 'sha512', followed by a '-' character.

By explicitly accepting `0` as an `id`, this non-breaking error will be avoided.